### PR TITLE
feat: add plaid_account_id to create/update transaction tools

### DIFF
--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -258,6 +258,12 @@ export function registerTransactionTools(server: McpServer) {
                                 .array(z.number())
                                 .optional()
                                 .describe("Array of tag IDs"),
+                            plaid_account_id: z
+                                .number()
+                                .optional()
+                                .describe(
+                                    "Plaid account ID to associate with this transaction",
+                                ),
                         }),
                     )
                     .describe("Array of transactions to create"),
@@ -404,6 +410,12 @@ export function registerTransactionTools(server: McpServer) {
                             .array(z.number())
                             .optional()
                             .describe("Array of tag IDs"),
+                        plaid_account_id: z
+                            .number()
+                            .optional()
+                            .describe(
+                                "Plaid account ID to associate with this transaction",
+                            ),
                     })
                     .describe("Transaction data to update"),
                 debit_as_negative: z


### PR DESCRIPTION
## Summary
- Add optional `plaid_account_id` parameter to `create_transactions` (per-transaction field) and `update_transaction` tools
- Aligns with the Feb 2025 LunchMoney API changelog: transactions can now be associated with Plaid accounts on create and update

🤖 Generated with [Claude Code](https://claude.com/claude-code)