### PR TITLE
fix: use z.coerce.number() for numeric tool params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.3] - 2026-03-20
+
+### Fixed
+
+- Use `z.coerce.number()` for all numeric tool parameters to accept string-typed values from MCP clients (fixes #8)
+
 ## [1.4.2] - 2026-02-18
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.3",
     "name": "lunchmoney",
     "display_name": "Lunch Money",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "Manage your Lunch Money finances with AI assistance",
     "long_description": "Connect Claude to your Lunch Money account to analyze spending patterns, manage budgets, track transactions, and get insights about your finances. This extension provides full access to Lunch Money's API, enabling you to manage categories, transactions, budgets, assets, and more through natural language commands.",
     "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@akutishevsky/lunchmoney-mcp",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "mcpName": "io.github.akutishevsky/lunchmoney-mcp",
     "description": "Model Context Protocol server for LunchMoney personal finance management",
     "main": "build/index.js",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
     "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
     "name": "io.github.akutishevsky/lunchmoney-mcp",
     "title": "Lunch Money",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "description": "MCP server for managing LunchMoney personal finances: transactions, budgets, categories, and more.",
     "websiteUrl": "https://github.com/akutishevsky/lunchmoney-mcp#readme",
     "repository": {
@@ -14,7 +14,7 @@
         {
             "registryType": "npm",
             "identifier": "@akutishevsky/lunchmoney-mcp",
-            "version": "1.4.2",
+            "version": "1.4.3",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -61,7 +61,9 @@ export function registerAssetTools(server: McpServer) {
                     .string()
                     .optional()
                     .describe("Display name of the asset (defaults to name)"),
-                balance: z.number().describe("Current balance of the asset"),
+                balance: z.coerce
+                    .number()
+                    .describe("Current balance of the asset"),
                 balance_as_of: z
                     .string()
                     .optional()
@@ -146,7 +148,9 @@ export function registerAssetTools(server: McpServer) {
         {
             description: "Update an existing manually-managed asset",
             inputSchema: {
-                asset_id: z.number().describe("ID of the asset to update"),
+                asset_id: z.coerce
+                    .number()
+                    .describe("ID of the asset to update"),
                 type_name: z
                     .enum([
                         "cash",

--- a/src/tools/assets.ts
+++ b/src/tools/assets.ts
@@ -177,7 +177,7 @@ export function registerAssetTools(server: McpServer) {
                     .string()
                     .optional()
                     .describe("Display name of the asset"),
-                balance: z
+                balance: z.coerce
                     .number()
                     .optional()
                     .describe("Current balance of the asset"),

--- a/src/tools/budgets.ts
+++ b/src/tools/budgets.ts
@@ -79,8 +79,10 @@ export function registerBudgetTools(server: McpServer) {
                     .string()
                     .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD format")
                     .describe("Budget month start date in YYYY-MM-DD format"),
-                category_id: z.number().describe("Category ID for the budget"),
-                amount: z.number().describe("Budget amount"),
+                category_id: z.coerce
+                    .number()
+                    .describe("Category ID for the budget"),
+                amount: z.coerce.number().describe("Budget amount"),
                 currency: z
                     .string()
                     .length(3)
@@ -129,7 +131,7 @@ export function registerBudgetTools(server: McpServer) {
                     .string()
                     .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD format")
                     .describe("Budget month start date in YYYY-MM-DD format"),
-                category_id: z
+                category_id: z.coerce
                     .number()
                     .describe("Category ID for the budget to remove"),
             },

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -49,7 +49,7 @@ export function registerCategoryTools(server: McpServer) {
             description:
                 "Get hydrated details on a single category. Note that if this category is part of a category group, its properties (is_income, exclude_from_budget, exclude_from_totals) will inherit from the category group.",
             inputSchema: {
-                categoryId: z
+                categoryId: z.coerce
                     .number()
                     .describe(
                         "Id of the category to query. Should call the get_all_categories tool first to get the ids.",
@@ -120,7 +120,7 @@ export function registerCategoryTools(server: McpServer) {
                     .boolean()
                     .optional()
                     .describe("Whether or not category should be archived."),
-                group_id: z
+                group_id: z.coerce
                     .number()
                     .optional()
                     .describe(
@@ -274,7 +274,7 @@ export function registerCategoryTools(server: McpServer) {
             description:
                 "Update the properties for a single category or category group.",
             inputSchema: {
-                categoryId: z
+                categoryId: z.coerce
                     .number()
                     .describe(
                         "Id of the category or category group to update. Execute the get_all_categories tool first, to get the category ids.",
@@ -316,7 +316,7 @@ export function registerCategoryTools(server: McpServer) {
                     .boolean()
                     .optional()
                     .describe("Whether or not category should be archived."),
-                group_id: z
+                group_id: z.coerce
                     .number()
                     .optional()
                     .describe(
@@ -376,7 +376,7 @@ export function registerCategoryTools(server: McpServer) {
             description:
                 "Add categories (either existing or new) to a single category group.",
             inputSchema: {
-                group_id: z
+                group_id: z.coerce
                     .number()
                     .describe("Id of the parent group to add to."),
                 category_ids: z
@@ -433,7 +433,7 @@ export function registerCategoryTools(server: McpServer) {
             description:
                 "Delete a single category or category group. This will only work if there are no dependencies, such as existing budgets for the category, categorized transactions, categorized recurring items, etc. If there are dependents, this endpoint will return what the dependents are and how many there are.",
             inputSchema: {
-                category_id: z
+                category_id: z.coerce
                     .number()
                     .describe(
                         "Id of the category or the category group to delete.",
@@ -467,7 +467,7 @@ export function registerCategoryTools(server: McpServer) {
             description:
                 "Delete a single category or category group and along with it, disassociate the category from any transactions, recurring items, budgets, etc. Note: it is best practice to first try the Delete Category endpoint to ensure you don't accidentally delete any data. Disassociation/deletion of the data arising from this endpoint is irreversible!",
             inputSchema: {
-                category_id: z
+                category_id: z.coerce
                     .number()
                     .describe(
                         "Id of the category or the category group to delete.",

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -209,7 +209,7 @@ export function registerCategoryTools(server: McpServer) {
                         "Whether or not transactions in this category should be excluded from calculated totals.",
                     ),
                 category_ids: z
-                    .array(z.number())
+                    .array(z.coerce.number())
                     .optional()
                     .describe(
                         "Array of category_id to include in the category group.",
@@ -380,7 +380,7 @@ export function registerCategoryTools(server: McpServer) {
                     .number()
                     .describe("Id of the parent group to add to."),
                 category_ids: z
-                    .array(z.number())
+                    .array(z.coerce.number())
                     .optional()
                     .describe(
                         "Array of category_id to include in the category group.",

--- a/src/tools/crypto.ts
+++ b/src/tools/crypto.ts
@@ -40,10 +40,10 @@ export function registerCryptoTools(server: McpServer) {
             description:
                 "Update a manually-managed cryptocurrency asset balance",
             inputSchema: {
-                crypto_id: z
+                crypto_id: z.coerce
                     .number()
                     .describe("ID of the crypto asset to update"),
-                balance: z
+                balance: z.coerce
                     .number()
                     .optional()
                     .describe("Updated balance of the crypto asset"),

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -28,15 +28,15 @@ export function registerTransactionTools(server: McpServer) {
                     .number()
                     .optional()
                     .describe("Filter by tag ID"),
-                recurring_id: z
+                recurring_id: z.coerce
                     .number()
                     .optional()
                     .describe("Filter by recurring expense ID"),
-                plaid_account_id: z
+                plaid_account_id: z.coerce
                     .number()
                     .optional()
                     .describe("Filter by Plaid account ID"),
-                category_id: z
+                category_id: z.coerce
                     .number()
                     .optional()
                     .describe("Filter by category ID"),
@@ -52,11 +52,11 @@ export function registerTransactionTools(server: McpServer) {
                     .string()
                     .optional()
                     .describe("Filter by status: cleared, uncleared, pending"),
-                offset: z
+                offset: z.coerce
                     .number()
                     .optional()
                     .describe("Number of transactions to skip"),
-                limit: z
+                limit: z.coerce
                     .number()
                     .optional()
                     .describe(
@@ -144,7 +144,7 @@ export function registerTransactionTools(server: McpServer) {
         {
             description: "Get details of a specific transaction",
             inputSchema: {
-                transaction_id: z
+                transaction_id: z.coerce
                     .number()
                     .describe("ID of the transaction to retrieve"),
                 debit_as_negative: z
@@ -217,15 +217,15 @@ export function registerTransactionTools(server: McpServer) {
                                 .describe(
                                     "Three-letter lowercase currency code",
                                 ),
-                            category_id: z
+                            category_id: z.coerce
                                 .number()
                                 .optional()
                                 .describe("Category ID"),
-                            asset_id: z
+                            asset_id: z.coerce
                                 .number()
                                 .optional()
                                 .describe("Asset ID for manual accounts"),
-                            recurring_id: z
+                            recurring_id: z.coerce
                                 .number()
                                 .optional()
                                 .describe("Recurring expense ID"),
@@ -246,7 +246,7 @@ export function registerTransactionTools(server: McpServer) {
                                 .array(z.coerce.number())
                                 .optional()
                                 .describe("Array of tag IDs"),
-                            plaid_account_id: z
+                            plaid_account_id: z.coerce
                                 .number()
                                 .optional()
                                 .describe(
@@ -332,7 +332,7 @@ export function registerTransactionTools(server: McpServer) {
         {
             description: "Update an existing transaction",
             inputSchema: {
-                transaction_id: z
+                transaction_id: z.coerce
                     .number()
                     .describe("ID of the transaction to update"),
                 transaction: z
@@ -357,15 +357,15 @@ export function registerTransactionTools(server: McpServer) {
                             .length(3)
                             .optional()
                             .describe("Three-letter lowercase currency code"),
-                        category_id: z
+                        category_id: z.coerce
                             .number()
                             .optional()
                             .describe("Category ID"),
-                        asset_id: z
+                        asset_id: z.coerce
                             .number()
                             .optional()
                             .describe("Asset ID for manual accounts"),
-                        recurring_id: z
+                        recurring_id: z.coerce
                             .number()
                             .optional()
                             .describe("Recurring expense ID"),
@@ -386,7 +386,7 @@ export function registerTransactionTools(server: McpServer) {
                             .array(z.coerce.number())
                             .optional()
                             .describe("Array of tag IDs"),
-                        plaid_account_id: z
+                        plaid_account_id: z.coerce
                             .number()
                             .optional()
                             .describe(
@@ -491,7 +491,7 @@ export function registerTransactionTools(server: McpServer) {
         {
             description: "Get details of a transaction group",
             inputSchema: {
-                transaction_id: z
+                transaction_id: z.coerce
                     .number()
                     .describe("ID of the transaction group"),
             },
@@ -531,7 +531,7 @@ export function registerTransactionTools(server: McpServer) {
                     .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD format")
                     .describe("Date in YYYY-MM-DD format"),
                 payee: z.string().describe("Payee name for the group"),
-                category_id: z
+                category_id: z.coerce
                     .number()
                     .optional()
                     .describe("Category ID for the group"),
@@ -580,7 +580,7 @@ export function registerTransactionTools(server: McpServer) {
         {
             description: "Delete a transaction group or a single transaction.",
             inputSchema: {
-                transaction_id: z
+                transaction_id: z.coerce
                     .number()
                     .describe("ID of the transaction group to delete"),
             },

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -24,7 +24,10 @@ export function registerTransactionTools(server: McpServer) {
                     .string()
                     .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD format")
                     .describe("End date in YYYY-MM-DD format"),
-                tag_id: z.number().optional().describe("Filter by tag ID"),
+                tag_id: z.coerce
+                    .number()
+                    .optional()
+                    .describe("Filter by tag ID"),
                 recurring_id: z
                     .number()
                     .optional()
@@ -37,7 +40,10 @@ export function registerTransactionTools(server: McpServer) {
                     .number()
                     .optional()
                     .describe("Filter by category ID"),
-                asset_id: z.number().optional().describe("Filter by asset ID"),
+                asset_id: z.coerce
+                    .number()
+                    .optional()
+                    .describe("Filter by asset ID"),
                 is_group: z
                     .boolean()
                     .optional()
@@ -237,7 +243,7 @@ export function registerTransactionTools(server: McpServer) {
                                 .optional()
                                 .describe("External ID (max 75 characters)"),
                             tags: z
-                                .array(z.number())
+                                .array(z.coerce.number())
                                 .optional()
                                 .describe("Array of tag IDs"),
                             plaid_account_id: z
@@ -377,7 +383,7 @@ export function registerTransactionTools(server: McpServer) {
                             .optional()
                             .describe("External ID (max 75 characters)"),
                         tags: z
-                            .array(z.number())
+                            .array(z.coerce.number())
                             .optional()
                             .describe("Array of tag IDs"),
                         plaid_account_id: z
@@ -446,7 +452,7 @@ export function registerTransactionTools(server: McpServer) {
             description: "Remove one or more transactions from a split",
             inputSchema: {
                 parent_ids: z
-                    .array(z.number())
+                    .array(z.coerce.number())
                     .describe("Array of parent transaction IDs to unsplit"),
                 remove_parents: z
                     .boolean()
@@ -531,11 +537,11 @@ export function registerTransactionTools(server: McpServer) {
                     .describe("Category ID for the group"),
                 notes: z.string().optional().describe("Notes for the group"),
                 tags: z
-                    .array(z.number())
+                    .array(z.coerce.number())
                     .optional()
                     .describe("Array of tag IDs for the group"),
                 transaction_ids: z
-                    .array(z.number())
+                    .array(z.coerce.number())
                     .describe("Array of transaction IDs to group"),
             },
             annotations: {


### PR DESCRIPTION
## Summary
- Use `z.coerce.number()` instead of `z.number()` for all numeric tool parameters across transactions, budgets, categories, assets, and crypto tools
- MCP clients (e.g. Claude Code) may send numeric arguments as strings, causing Zod validation errors — coercion fixes this
- Bump version to 1.4.3

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)