### PR TITLE
Expose createServer factory and subpath exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A Model Context Protocol (MCP) server implementation for [LunchMoney](https://lu
         - [Codex CLI](#codex-cli)
         - [Manual MCP Configuration](#manual-mcp-configuration)
     - [Standalone Server](#standalone-server)
+- [Remote Deployments](#remote-deployments)
 - [Example Prompts](#example-prompts)
 - [Available Tools](#available-tools)
 - [Development](#development)
@@ -189,6 +190,42 @@ Different MCP clients store their configuration in different locations:
 # Run with npx
 LUNCHMONEY_API_TOKEN="your-api-token" npx @akutishevsky/lunchmoney-mcp
 ```
+
+## Remote Deployments
+
+The bundled stdio binary covers desktop MCP clients, but Claude on mobile and the [custom connectors](https://support.anthropic.com/en/articles/11503834-using-custom-connectors-with-claude) feature in [claude.ai](https://claude.ai) only speak HTTP. There are two ways to expose this server remotely.
+
+### Turnkey: Cloudflare Workers
+
+[lunchmoney-mcp-cloudflare](https://github.com/bm1549/lunchmoney-mcp-cloudflare) wraps this package as a Cloudflare Worker with Google sign-in and an email allowlist in front of the MCP endpoint. The whole stack fits inside Cloudflare's and Google Cloud's free tiers, and a `setup.sh` wizard handles KV creation, OAuth client setup, secrets, and deploy in one walkthrough. Each authenticated user runs in their own Durable Object, so the [config singleton](#embedding-as-a-library) stays per-user.
+
+### Self-hosted: HTTP transport on your own host
+
+For a single-user deployment, wire `createServer()` into [`StreamableHTTPServerTransport`](https://github.com/modelcontextprotocol/typescript-sdk#streamable-http-transport) and serve it from any Node HTTP framework. Example with Express:
+
+```ts
+import express from "express";
+import { createServer } from "@akutishevsky/lunchmoney-mcp/server";
+import { initializeConfig } from "@akutishevsky/lunchmoney-mcp/config";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+initializeConfig(process.env.LUNCHMONEY_API_TOKEN!);
+const server = createServer("1.0.0");
+
+const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => crypto.randomUUID(),
+});
+await server.connect(transport);
+
+const app = express();
+app.use(express.json());
+app.all("/mcp", (req, res) => transport.handleRequest(req, res, req.body));
+app.listen(3000);
+```
+
+Swap Express for Hono (via `@hono/node-server`) or Fastify if you prefer — the transport only needs Node's `IncomingMessage` and `ServerResponse`. Add your own auth in front of `/mcp` — the package ships no transport-level auth.
+
+> **Multi-tenant warning.** This pattern serves one user from one process with one shared API token. To serve multiple users from a single Node process you'd hit the [single-tenant config singleton](#embedding-as-a-library); fork the process per user or use the Cloudflare option above (each user gets their own isolate).
 
 ## Example Prompts
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,23 @@ npm run build:mcpb
 3. Register tools in `src/index.ts`
 4. Add types to `src/types.ts` if needed
 
+### Embedding as a library
+
+The package exposes subpath entry points so it can be embedded in a custom transport (for example, a Cloudflare Worker that serves the MCP protocol over HTTP) rather than only the bundled stdio binary:
+
+```ts
+import { createServer } from "@akutishevsky/lunchmoney-mcp/server";
+import { initializeConfig } from "@akutishevsky/lunchmoney-mcp/config";
+
+initializeConfig(process.env.LUNCHMONEY_API_TOKEN!);
+const server = createServer("1.0.0");
+// connect `server` to whatever transport you need
+```
+
+`initializeConfig` must be called before any tool is invoked, or the first request throws `"Configuration not initialized."`.
+
+> **Single-tenant assumption.** The config is held in a module-level singleton. That is safe on per-isolate runtimes — each user gets their own isolate, so there is no shared mutable state to race on. It is **not** safe on shared-process multi-tenant Node hosts (e.g. one Express or Hono process serving multiple users): concurrent `initializeConfig` calls would race and leak tokens between requests. Those consumers need to fork per-user or refactor the singleton before exposing the package.
+
 ## API Reference
 
 The server implements the full LunchMoney API v2. For detailed API documentation, see:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,29 @@
     "bin": {
         "lunchmoney-mcp": "./build/index.js"
     },
+    "exports": {
+        ".": {
+            "types": "./build/index.d.ts",
+            "default": "./build/index.js"
+        },
+        "./server": {
+            "types": "./build/server.d.ts",
+            "import": "./build/server.js"
+        },
+        "./config": {
+            "types": "./build/config.d.ts",
+            "import": "./build/config.js"
+        },
+        "./prompts": {
+            "types": "./build/prompts.d.ts",
+            "import": "./build/prompts.js"
+        },
+        "./tools/*": {
+            "types": "./build/tools/*.d.ts",
+            "import": "./build/tools/*.js"
+        },
+        "./package.json": "./package.json"
+    },
     "scripts": {
         "build:mcpb": "npm run build && mkdir -p dist && npx @anthropic-ai/mcpb pack . dist/lunchmoney.mcpb",
         "build": "tsc && chmod 755 build/index.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "exports": {
         ".": {
             "types": "./build/index.d.ts",
-            "default": "./build/index.js"
+            "import": "./build/index.js"
         },
         "./server": {
             "types": "./build/server.d.ts",
@@ -23,10 +23,6 @@
         "./prompts": {
             "types": "./build/prompts.d.ts",
             "import": "./build/prompts.js"
-        },
-        "./tools/*": {
-            "types": "./build/tools/*.d.ts",
-            "import": "./build/tools/*.js"
         },
         "./package.json": "./package.json"
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,15 +5,15 @@ interface Config {
 
 let config: Config | null = null;
 
-const initializeConfig = (): Config => {
-    if (!process.env.LUNCHMONEY_API_TOKEN) {
+const initializeConfig = (lunchmoneyApiToken: string): Config => {
+    if (!lunchmoneyApiToken) {
         throw new Error(
-            "Failed to get the LUNCHMONEY_API_TOKEN. Probably it wasn't added during the server configuration.",
+            "LunchMoney API token is required. Pass it to initializeConfig().",
         );
     }
 
     config = {
-        lunchmoneyApiToken: process.env.LUNCHMONEY_API_TOKEN,
+        lunchmoneyApiToken,
         baseUrl: "https://api.lunchmoney.dev/v2",
     };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,25 @@ interface Config {
 
 let config: Config | null = null;
 
+/**
+ * Set the LunchMoney API token used by every tool in this package.
+ *
+ * Must be called before `createServer()` is connected to a transport, or
+ * before any individual tool is invoked.
+ *
+ * ⚠️ Single-tenant assumption: the config is stored in a module-level
+ * singleton, so two concurrent requests in the same process can race and
+ * read each other's tokens. This is safe on per-isolate runtimes
+ * (Cloudflare Workers + Durable Objects, AWS Lambda) and on single-user
+ * stdio deployments. It is NOT safe on shared-process multi-tenant hosts
+ * (e.g. a single Node process serving multiple users via Express or Hono);
+ * those consumers need to either fork per-user or refactor the singleton
+ * before exposing this package.
+ *
+ * @param lunchmoneyApiToken - Personal API token from
+ *   https://my.lunchmoney.app/developers.
+ * @throws If `lunchmoneyApiToken` is empty.
+ */
 const initializeConfig = (lunchmoneyApiToken: string): Config => {
     if (!lunchmoneyApiToken) {
         throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,13 @@ const { version } = require("../package.json");
 
 (async () => {
     try {
-        initializeConfig();
+        const token = process.env.LUNCHMONEY_API_TOKEN;
+        if (!token) {
+            throw new Error(
+                "Failed to get the LUNCHMONEY_API_TOKEN. Probably it wasn't added during the server configuration.",
+            );
+        }
+        initializeConfig(token);
 
         const server = createServer(version);
         const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,42 +1,17 @@
 #!/usr/bin/env node
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createRequire } from "module";
 import { initializeConfig } from "./config.js";
-import { registerUserTools } from "./tools/user.js";
-import { registerCategoryTools } from "./tools/categories.js";
-import { registerTagTools } from "./tools/tags.js";
-import { registerTransactionTools } from "./tools/transactions.js";
-import { registerRecurringItemsTools } from "./tools/recurring-items.js";
-import { registerBudgetTools } from "./tools/budgets.js";
-import { registerManualAccountTools } from "./tools/manual-accounts.js";
-import { registerPlaidAccountTools } from "./tools/plaid-accounts.js";
-import { registerCryptoTools } from "./tools/crypto.js";
-import { registerPrompts } from "./prompts.js";
+import { createServer } from "./server.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json");
-
-const server = new McpServer({
-    name: "lunchmoney-mcp",
-    version,
-});
-
-registerUserTools(server);
-registerCategoryTools(server);
-registerTagTools(server);
-registerTransactionTools(server);
-registerRecurringItemsTools(server);
-registerBudgetTools(server);
-registerManualAccountTools(server);
-registerPlaidAccountTools(server);
-registerCryptoTools(server);
-registerPrompts(server);
 
 (async () => {
     try {
         initializeConfig();
 
+        const server = createServer(version);
         const transport = new StdioServerTransport();
         await server.connect(transport);
         console.error("Lunchmoney MCP Server running on stdio");

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,31 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerUserTools } from "./tools/user.js";
+import { registerCategoryTools } from "./tools/categories.js";
+import { registerTagTools } from "./tools/tags.js";
+import { registerTransactionTools } from "./tools/transactions.js";
+import { registerRecurringItemsTools } from "./tools/recurring-items.js";
+import { registerBudgetTools } from "./tools/budgets.js";
+import { registerManualAccountTools } from "./tools/manual-accounts.js";
+import { registerPlaidAccountTools } from "./tools/plaid-accounts.js";
+import { registerCryptoTools } from "./tools/crypto.js";
+import { registerPrompts } from "./prompts.js";
+
+export function createServer(version: string): McpServer {
+    const server = new McpServer({
+        name: "lunchmoney-mcp",
+        version,
+    });
+
+    registerUserTools(server);
+    registerCategoryTools(server);
+    registerTagTools(server);
+    registerTransactionTools(server);
+    registerRecurringItemsTools(server);
+    registerBudgetTools(server);
+    registerManualAccountTools(server);
+    registerPlaidAccountTools(server);
+    registerCryptoTools(server);
+    registerPrompts(server);
+
+    return server;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,17 @@ import { registerPlaidAccountTools } from "./tools/plaid-accounts.js";
 import { registerCryptoTools } from "./tools/crypto.js";
 import { registerPrompts } from "./prompts.js";
 
+/**
+ * Build a configured `McpServer` with all LunchMoney tools and prompts registered.
+ *
+ * `initializeConfig(token)` from `./config` must be called before any tool is
+ * invoked. The returned server is wired up but inert — actual API calls go
+ * through the module-level config singleton, which throws
+ * `"Configuration not initialized. Call initializeConfig() first."` on the
+ * first tool invocation if no token has been set.
+ *
+ * @param version - Version string surfaced to MCP clients as `serverInfo.version`.
+ */
 export function createServer(version: string): McpServer {
     const server = new McpServer({
         name: "lunchmoney-mcp",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "moduleResolution": "NodeNext",
         "outDir": "./build",
         "rootDir": "./src",
+        "declaration": true,
         "isolatedModules": true,
         "sourceMap": true,
         "strict": true,


### PR DESCRIPTION
I wanted to use this MCP server from the Claude mobile app, which only supports remote (HTTP) connectors — not stdio. That meant wrapping it in a Cloudflare Worker with OAuth in front, and calling `createServer` from outside the existing stdio entrypoint.

The wrapper is open-source in two repos:
- [remote-mcp-cloudflare](https://github.com/bm1549/remote-mcp-cloudflare) — generic worker scaffolding (Google OAuth + email allowlist + Durable Object transport)
- [lunchmoney-mcp-cloudflare](https://github.com/bm1549/lunchmoney-mcp-cloudflare) — thin consumer that wires this package in, with a `setup.sh` wizard

I also wanted the whole stack to fit inside Cloudflare's and Google Cloud's free tiers, so anyone with a LunchMoney account can stand one up for $0. That kept the upstream surface I needed pretty small:

1. Pull `McpServer` construction into a `createServer(version)` factory.
2. Replace module-level `process.env` reads with `initializeConfig(token)` — `process.env` doesn't run reliably inside Worker isolates, so the wrapper has to inject the token.
3. Emit `.d.ts` declarations and add subpath exports (`./server`, `./config`, `./prompts`, `./tools/*`) so consumers can `import { createServer } from "@akutishevsky/lunchmoney-mcp/server"`.

No behavior change to the stdio binary — `npm start` works the same. Can split into three separate PRs if that's easier to review; they're already stacked on my fork as [pr1](https://github.com/bm1549/lunchmoney-mcp/tree/pr1-extract-create-server-factory) / [pr2](https://github.com/bm1549/lunchmoney-mcp/tree/pr2-decouple-config-from-env) / [pr3](https://github.com/bm1549/lunchmoney-mcp/tree/pr3-emit-declarations-add-exports).