### PR TITLE
fix: properly compact objects when converting to toon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ A husky pre-commit hook runs `npm run format` automatically before every commit.
 
 **Tools:** `src/tools/` — one file per domain. Each exports a `register[Domain]Tools(server: McpServer)` function called from `index.ts`.
 
-**Response format:** `src/format.ts` — uses [TOON](https://github.com/nicfontaine/toon) encoding instead of JSON for tool responses. TOON is a compact text format that reduces token count by stripping quotes and braces. Null fields are stripped before encoding to further reduce payload size.
+**Response format:** `src/format.ts` — uses [TOON](https://github.com/nicfontaine/toon) encoding instead of JSON for tool responses. TOON is a compact text format that reduces token count by stripping quotes and braces. Before encoding, `compact()` drops object keys that are blank (null/undefined/empty array) in every element of an array, while keeping keys that are partially present as explicit nulls. This preserves key uniformity across rows so TOON emits its compact tabular form (header once, rows as CSV) instead of a verbose repeated-key list. Primitive arrays (e.g. `tag_ids`) are joined into a single `|`-delimited scalar so they don't disqualify a row from the tabular form; arrays of objects (e.g. `children`, `files`) are left intact and compacted recursively.
 
 ## Tool Implementation Pattern
 

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ The easiest way to install this server is as an MCP Bundle in Claude Desktop:
 Add the LunchMoney MCP server to Claude Code:
 
 ```bash
-claude mcp add --transport stdio --env LUNCHMONEY_API_TOKEN=your-api-token-here lunchmoney -- npx -y @akutishevsky/lunchmoney-mcp
+claude mcp add lunchmoney --transport stdio -e LUNCHMONEY_API_TOKEN=your-api-token-here -- npx -y @akutishevsky/lunchmoney-mcp
 ```
 
 To enable debug logging:
 
 ```bash
-claude mcp add --transport stdio --env LUNCHMONEY_API_TOKEN=your-api-token-here --env LUNCHMONEY_DEBUG=true lunchmoney -- npx -y @akutishevsky/lunchmoney-mcp
+claude mcp add lunchmoney --transport stdio -e LUNCHMONEY_API_TOKEN=your-api-token-here -e LUNCHMONEY_DEBUG=true -- npx -y @akutishevsky/lunchmoney-mcp
 ```
 
 Verify the server was added:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@akutishevsky/lunchmoney-mcp",
-    "version": "2.1.0",
+    "version": "2.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@akutishevsky/lunchmoney-mcp",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.17.0",
@@ -373,6 +373,7 @@
             "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.55.0",
                 "@typescript-eslint/types": "8.55.0",
@@ -603,6 +604,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -994,6 +996,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -1201,6 +1204,7 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -1524,6 +1528,7 @@
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
             "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -2010,6 +2015,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2419,6 +2425,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -2535,6 +2542,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@akutishevsky/lunchmoney-mcp",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@akutishevsky/lunchmoney-mcp",
-            "version": "2.0.1",
+            "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.17.0",
@@ -373,7 +373,6 @@
             "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.55.0",
                 "@typescript-eslint/types": "8.55.0",
@@ -604,7 +603,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -996,7 +994,6 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -1204,7 +1201,6 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -1528,7 +1524,6 @@
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
             "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -2015,7 +2010,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2425,7 +2419,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -2542,7 +2535,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,18 +1,54 @@
 import { encode } from "@toon-format/toon";
 
-function stripNulls(value: unknown): unknown {
-    if (value === null) return undefined;
-    if (Array.isArray(value)) return value.map(stripNulls);
-    if (typeof value === "object") {
-        const result: Record<string, unknown> = {};
-        for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-            if (v !== null) result[k] = stripNulls(v);
+function isBlank(value: unknown): boolean {
+    if (value === null || value === undefined) return true;
+    return Array.isArray(value) && value.length === 0;
+}
+
+function isPrimitiveArray(arr: unknown[]): boolean {
+    return arr.every((el) => el === null || typeof el !== "object");
+}
+
+// For an array of objects, drop a key only when it is blank in EVERY row, and
+// keep partially-present keys as explicit nulls. Uniform keys across rows let
+// TOON emit its compact tabular form (header once, rows as CSV) instead of a
+// verbose repeated-key list. Primitive-array values are joined to a single
+// scalar by compact() so they don't disqualify a row from the tabular form.
+function compactArray(arr: unknown[]): unknown[] {
+    const allObjects =
+        arr.length > 0 &&
+        arr.every(
+            (el) => el !== null && typeof el === "object" && !Array.isArray(el),
+        );
+    if (!allObjects) return arr.map(compact);
+
+    const rows = arr as Record<string, unknown>[];
+    const keys = [...new Set(rows.flatMap((row) => Object.keys(row)))];
+    const kept = keys.filter((k) => rows.some((row) => !isBlank(row[k])));
+
+    return rows.map((row) => {
+        const out: Record<string, unknown> = {};
+        for (const k of kept) {
+            out[k] = isBlank(row[k]) ? null : compact(row[k]);
         }
-        return result;
+        return out;
+    });
+}
+
+function compact(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        if (isPrimitiveArray(value)) return value.join("|");
+        return compactArray(value);
     }
-    return value;
+    if (value === null || typeof value !== "object") return value;
+
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+        if (!isBlank(v)) out[k] = compact(v);
+    }
+    return out;
 }
 
 export function formatData(data: unknown): string {
-    return encode(stripNulls(data));
+    return encode(compact(data));
 }


### PR DESCRIPTION
Hi there, 

I'm a new user to Lunch Money. This MCP server really helped me with categorizing my transactions faster! However, I felt like it was a bit of a token cannon and originally just sought to replace the output with minified JSON. With a little bit of work, I found a bug that prevented objects from being compacted when they could've been. 

The `stripNulls` function deleted null keys per object, meaning each row in the table didn't have the same keyset. The new `compact` function only drops keys that are blank for every row and allows partially blank values to report `null`. It also joins standard arrays into a string separate by `|` (`results|look|like|this`).

In testing with `claude-opus-4-8` this turned a 72,177 token output to only 39,933 tokens, saving about $0.16 per turn.

Thanks!

PS: I noticed when I ran `npm install` it regenerated the lockfile, and I updated the documented Claude Code commands to be what worked for me in my own installation.