### PR TITLE
fix(security): confine and content-verify transaction attachments (#16)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v5
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v5
+              with:
+                  node-version: "lts/*"
+                  cache: "npm"
+
+            - name: Install dependencies
+              run: npm ci
+
+            # Builds first: the suite exercises the compiled output in build/,
+            # so this covers typechecking as well.
+            - name: Run tests
+              run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@ All notable changes to this project will be documented in this file.
 - **`attach_file_to_transaction` no longer reads arbitrary files** ([#16](https://github.com/akutishevsky/lunchmoney-mcp/issues/16)). The tool passed the caller-supplied `file_path` straight to `readFile` with no confinement, and its MIME allow-list checked a caller-supplied `content_type` rather than the file, so any readable path — `~/.ssh/id_rsa`, a `.env`, `/etc/passwd` — could be uploaded to the LunchMoney attachments endpoint and retrieved again via `get_transaction_attachment_url`. Four changes:
     - The attachment type is now determined by sniffing the file's leading bytes, and the header is checked before the rest of the file is read. Non-media files are rejected without ever being buffered.
     - New optional `LUNCHMONEY_ATTACHMENTS_DIR` confines reads to one directory, enforced after `realpath` so `..` traversal and symlink escapes are both caught. Unset leaves reads unconfined, which preserves existing desktop behaviour; **remote/HTTP deployments should always set it**.
-    - Size is now checked via `stat` before any bytes are buffered, and non-regular files are rejected — previously `readFile("/dev/zero")` would grow unbounded and exhaust memory.
+    - Size is now checked via `stat` before any bytes are buffered, and non-regular files are rejected — previously `readFile("/dev/zero")` would grow unbounded and exhaust memory. The file is opened with `O_NONBLOCK`, because a read-only `open(2)` on a FIFO blocks until a writer appears; without it a caller could hang a request indefinitely, pin a libuv threadpool thread, and prevent clean shutdown.
     - Filesystem errors are logged to stderr but reported to the caller generically, so failed reads no longer distinguish `ENOENT` from `EACCES` and leak filesystem structure.
 
 ### Changed
 
-- `attach_file_to_transaction`'s `content_type` parameter is now an optional enum of the allowed types and is treated as an assertion: the file's real type always wins, and a mismatch is rejected rather than silently corrected. Previously it selected the declared type outright.
+- `attach_file_to_transaction`'s `content_type` parameter is now an optional enum of the allowed types and is treated as an assertion: the file's real type always wins, and a mismatch is rejected rather than silently corrected. Previously it selected the declared type outright. HEIC and HEIF are exempt from the mismatch check, since the ISO-BMFF major brand does not reliably distinguish them (many `.HEIC` files, iOS ones included, carry `mif1`).
+
+### Fixed
+
+- `%PDF-` is no longer required at byte 0. The PDF spec tolerates leading bytes and conforming readers scan for the marker, so PDFs from scanners that emit a preamble were being rejected.
+- An unset optional `user_config` field in a `.mcpb` install arrives as the literal `${user_config.LUNCHMONEY_ATTACHMENTS_DIR}` template rather than being omitted. That string is truthy, so it was treated as a configured directory and made `attach_file_to_transaction` fail for every Claude Desktop user who left the field blank. Unsubstituted templates are now treated as unset.
 
 ## [2.1.1] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,13 @@ All notable changes to this project will be documented in this file.
     - Size is now checked via `stat` before any bytes are buffered, and non-regular files are rejected — previously `readFile("/dev/zero")` would grow unbounded and exhaust memory. The file is opened with `O_NONBLOCK`, because a read-only `open(2)` on a FIFO blocks until a writer appears; without it a caller could hang a request indefinitely, pin a libuv threadpool thread, and prevent clean shutdown.
     - Filesystem errors are logged to stderr but reported to the caller generically, so failed reads no longer distinguish `ENOENT` from `EACCES` and leak filesystem structure.
 
+### Added
+
+- **Test suite** (`npm test`), the project's first. Runs on Node's built-in test runner over the compiled output, so it typechecks as well. 78 tests covering `src/attachments.ts` — content sniffing, path confinement, resource limits — plus the `attach_file_to_transaction` tool boundary driven through a real MCP client over an in-memory transport. Every regression described in this release has a test pinning it. Wired into CI via `.github/workflows/test.yml`.
+
 ### Changed
 
+- Attachment reading moved out of `src/tools/transactions.ts` into `src/attachments.ts`, so it can be unit-tested without standing up an `McpServer`. No behaviour change.
 - `attach_file_to_transaction`'s `content_type` parameter is now an optional enum of the allowed types and is treated as an assertion: the file's real type always wins, and a mismatch is rejected rather than silently corrected. Previously it selected the declared type outright. HEIC and HEIF are exempt from the mismatch check, since the ISO-BMFF major brand does not reliably distinguish them (many `.HEIC` files, iOS ones included, carry `mif1`).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Security
+
+- **`attach_file_to_transaction` no longer reads arbitrary files** ([#16](https://github.com/akutishevsky/lunchmoney-mcp/issues/16)). The tool passed the caller-supplied `file_path` straight to `readFile` with no confinement, and its MIME allow-list checked a caller-supplied `content_type` rather than the file, so any readable path — `~/.ssh/id_rsa`, a `.env`, `/etc/passwd` — could be uploaded to the LunchMoney attachments endpoint and retrieved again via `get_transaction_attachment_url`. Four changes:
+    - The attachment type is now determined by sniffing the file's leading bytes, and the header is checked before the rest of the file is read. Non-media files are rejected without ever being buffered.
+    - New optional `LUNCHMONEY_ATTACHMENTS_DIR` confines reads to one directory, enforced after `realpath` so `..` traversal and symlink escapes are both caught. Unset leaves reads unconfined, which preserves existing desktop behaviour; **remote/HTTP deployments should always set it**.
+    - Size is now checked via `stat` before any bytes are buffered, and non-regular files are rejected — previously `readFile("/dev/zero")` would grow unbounded and exhaust memory.
+    - Filesystem errors are logged to stderr but reported to the caller generically, so failed reads no longer distinguish `ENOENT` from `EACCES` and leak filesystem structure.
+
+### Changed
+
+- `attach_file_to_transaction`'s `content_type` parameter is now an optional enum of the allowed types and is treated as an assertion: the file's real type always wins, and a mismatch is rejected rather than silently corrected. Previously it selected the declared type outright.
+
 ## [2.1.1] - 2026-05-31
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,13 @@ MCP (Model Context Protocol) server for the LunchMoney personal finance API (v2)
 - `npm run dev` — run with MCP Inspector (set `LUNCHMONEY_API_TOKEN` in the script first)
 - `npm run format` — run Prettier on the entire codebase
 
-No test suite exists; test via `npm run dev` with the MCP Inspector against a real LunchMoney account.
+- `npm test` — build, then run the test suite with Node's built-in runner
+
+Tests live in `test/*.test.mjs` and are plain ESM JavaScript, not TypeScript: `tsconfig.json` sets `rootDir: ./src`, so tests can't be compiled by the main build. They import the **compiled** output from `build/`, which is why `npm test` builds first — that also makes the run a typecheck. Shared fixtures (sandbox directories, magic-byte samples, env-var juggling) live in `test/helpers.mjs`; use them rather than rolling new ones.
+
+Coverage is currently limited to `src/attachments.ts`, the security-sensitive path from [issue #16](https://github.com/akutishevsky/lunchmoney-mcp/issues/16). The tool handlers themselves are still exercised manually via `npm run dev` with the MCP Inspector against a real LunchMoney account.
+
+`npm run lint` is currently broken — `typescript-eslint` does not yet support TypeScript 7. This predates the test suite.
 
 A husky pre-commit hook runs `npm run format` automatically before every commit.
 
@@ -26,6 +32,8 @@ A husky pre-commit hook runs `npm run format` automatically before every commit.
 **Debug logging:** Set `LUNCHMONEY_DEBUG=true` to log API requests and responses (method, path, status, duration, body) to stderr. Controlled via `isDebug()` in `src/api.ts`.
 
 **Types:** `src/types.ts` — TypeScript interfaces matching LunchMoney API response shapes (snake_case field names).
+
+**Attachments:** `src/attachments.ts` — reads local files for `attach_file_to_transaction`. Treats `file_path` as hostile input, since it reaches the server from a model that may be acting on untrusted content. The MIME type is decided by sniffing the file's leading bytes, never by its extension or the caller's `content_type`; the optional `LUNCHMONEY_ATTACHMENTS_DIR` confines reads to one directory, enforced after `realpath`. Kept as its own module so it can be unit-tested without standing up an `McpServer`. Changes here need a matching test in `test/`.
 
 **Tools:** `src/tools/` — one file per domain. Each exports a `register[Domain]Tools(server: McpServer)` function called from `index.ts`.
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ The server can be configured in your MCP client's configuration file. The exact 
 
 > **Note:** `LUNCHMONEY_DEBUG` is optional. Set it to `"true"` to enable debug logging of API requests and responses to stderr. Useful for troubleshooting.
 
+> **Note:** `LUNCHMONEY_ATTACHMENTS_DIR` is optional. `attach_file_to_transaction` is the only tool that reads from your filesystem, and it always verifies that a file really is a JPEG, PNG, HEIC, HEIF, or PDF before uploading it. Set this variable to a directory (say, a `~/Receipts` folder) to additionally restrict it to files inside that directory — `..` and symlinks that point outside are rejected. Leave it unset and any path the server can read is fair game, which is usually fine for a local stdio server but **not** for [remote deployments](#remote-deployments).
+
 Replace `"your-api-token-here"` with your actual LunchMoney API token from [LunchMoney Developer Settings](https://my.lunchmoney.app/developers).
 
 ##### Common MCP Client Configuration Locations
@@ -225,6 +227,8 @@ app.listen(3000);
 ```
 
 Swap Express for Hono (via `@hono/node-server`) or Fastify if you prefer — the transport only needs Node's `IncomingMessage` and `ServerResponse`. Add your own auth in front of `/mcp` — the package ships no transport-level auth.
+
+> **Set `LUNCHMONEY_ATTACHMENTS_DIR` on any remote deployment.** `attach_file_to_transaction` reads a path supplied by the caller off the host's filesystem. On a desktop stdio server the caller and the file owner are the same person, so that is unremarkable. Once the server is reachable over HTTP they are different principals, and an unconfined read is a way for a remote caller — or a prompt-injected model — to pull files off your host. Point the variable at a dedicated directory and keep nothing else in it. The content-type check (only real JPEG/PNG/HEIC/HEIF/PDF files upload) applies either way, but it is a backstop, not a substitute.
 
 > **Multi-tenant warning.** This pattern serves one user from one process with one shared API token. To serve multiple users from a single Node process you'd hit the [single-tenant config singleton](#embedding-as-a-library); fork the process per user or use the Cloudflare option above (each user gets their own isolate).
 
@@ -335,7 +339,7 @@ Here are some example prompts you can use with the LunchMoney MCP server:
 - `delete_transaction_group` - Ungroup a transaction group
 - `split_transaction` - Split a transaction into 2–500 children
 - `unsplit_transaction` - Undo a previous split
-- `attach_file_to_transaction` - Upload a local file (jpeg/png/heic/heif/pdf, ≤10MB)
+- `attach_file_to_transaction` - Upload a local file (jpeg/png/heic/heif/pdf, ≤10MB), type verified from its contents
 - `get_transaction_attachment_url` - Get a signed download URL for a file attachment
 - `delete_transaction_attachment` - Delete a file attachment
 

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,8 @@
             "args": ["${__dirname}/build/index.js"],
             "env": {
                 "LUNCHMONEY_API_TOKEN": "${user_config.LUNCHMONEY_API_TOKEN}",
-                "LUNCHMONEY_DEBUG": "${user_config.LUNCHMONEY_DEBUG}"
+                "LUNCHMONEY_DEBUG": "${user_config.LUNCHMONEY_DEBUG}",
+                "LUNCHMONEY_ATTACHMENTS_DIR": "${user_config.LUNCHMONEY_ATTACHMENTS_DIR}"
             }
         }
     },
@@ -170,7 +171,7 @@
         },
         {
             "name": "attach_file_to_transaction",
-            "description": "Upload a local file (jpeg/png/heic/heif/pdf, max 10MB) and attach it to a transaction."
+            "description": "Upload a local file (jpeg/png/heic/heif/pdf, max 10MB) and attach it to a transaction. The type is verified from the file's contents, and reads can be confined to a directory via LUNCHMONEY_ATTACHMENTS_DIR."
         },
         {
             "name": "get_transaction_attachment_url",
@@ -238,6 +239,13 @@
             "type": "boolean",
             "title": "Debug Logging",
             "description": "Enable debug logging of API requests and responses to stderr",
+            "required": false,
+            "sensitive": false
+        },
+        "LUNCHMONEY_ATTACHMENTS_DIR": {
+            "type": "directory",
+            "title": "Attachments Directory",
+            "description": "Optional. Confine attach_file_to_transaction to this directory, so the server can only read receipt files you have placed inside it. Leave unset to allow any path readable by the server.",
             "required": false,
             "sensitive": false
         }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "build": "tsc && chmod 755 build/index.js",
         "dev": "LUNCHMONEY_API_TOKEN='YOUR_TOKEN_HERE' LUNCHMONEY_DEBUG='true' npx @modelcontextprotocol/inspector node build/index.js",
         "format": "prettier --write .",
+        "test": "npm run build && node --test 'test/**/*.test.mjs'",
         "lint": "eslint src/",
         "inspect": "npx @modelcontextprotocol/inspector node build/index.js",
         "prepare": "husky",

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -1,0 +1,218 @@
+import { constants } from "node:fs";
+import { open, realpath } from "node:fs/promises";
+import { resolve, sep } from "node:path";
+
+const { O_RDONLY, O_NONBLOCK } = constants;
+
+export const ALLOWED_ATTACHMENT_MIME_TYPES = [
+    "image/jpeg",
+    "image/png",
+    "image/heic",
+    "image/heif",
+    "application/pdf",
+] as const;
+
+export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+
+// The image signatures all sit in the first 12 bytes, but the PDF spec allows
+// junk before `%PDF-` and conforming readers scan the first 1024 bytes for it,
+// so the window has to be wide enough to match what real scanners emit.
+const ATTACHMENT_HEADER_BYTES = 1024;
+const PNG_SIGNATURE = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+// ISO-BMFF major brands. HEIC and HEIF share a container; the brand decides
+// which of the two MIME types the LunchMoney API expects. Plenty of real
+// `.HEIC` files (iOS among them) carry `mif1` as the major brand and list
+// `heic` only as a compatible brand, so the two are treated as interchangeable
+// when checking a caller's `content_type` assertion.
+const HEIC_BRANDS = new Set(["heic", "heix", "hevc", "hevx"]);
+const HEIF_BRANDS = new Set(["mif1", "msf1", "heim", "heis", "hevm", "hevs"]);
+const HEIF_FAMILY = new Set<string>(["image/heic", "image/heif"]);
+
+/**
+ * Whether a caller's `content_type` assertion is compatible with the type the
+ * file's own bytes reported.
+ *
+ * HEIC and HEIF are interchangeable here: the ISO-BMFF major brand does not
+ * reliably distinguish them, so a caller calling an `mif1` file `image/heic`
+ * is right rather than confused. Both are accepted types regardless.
+ */
+export function contentTypeMatches(declared: string, actual: string): boolean {
+    if (declared === actual) return true;
+    return HEIF_FAMILY.has(declared) && HEIF_FAMILY.has(actual);
+}
+
+/**
+ * Identify an attachment by its leading bytes.
+ *
+ * The file extension and any caller-supplied MIME type are both untrusted —
+ * only the contents decide. Returns `null` for anything that is not one of the
+ * types the LunchMoney attachments endpoint accepts, which is what stops the
+ * attach tool from being used to read arbitrary non-media files off the host.
+ */
+export function sniffMimeType(header: Buffer): string | null {
+    if (
+        header.length >= 3 &&
+        header[0] === 0xff &&
+        header[1] === 0xd8 &&
+        header[2] === 0xff
+    ) {
+        return "image/jpeg";
+    }
+    if (header.length >= 8 && header.subarray(0, 8).equals(PNG_SIGNATURE)) {
+        return "image/png";
+    }
+    // Not anchored at offset 0: the PDF spec tolerates bytes before the header
+    // and conforming readers scan for it, as do the scanners that produce some
+    // receipts. Files of the kind this check exists to exclude — keys,
+    // credentials, `/etc/passwd` — do not contain this marker, so the wider
+    // window is free.
+    if (header.includes("%PDF-", 0, "latin1")) {
+        return "application/pdf";
+    }
+    if (
+        header.length >= 12 &&
+        header.subarray(4, 8).toString("latin1") === "ftyp"
+    ) {
+        const brand = header.subarray(8, 12).toString("latin1");
+        if (HEIC_BRANDS.has(brand)) return "image/heic";
+        if (HEIF_BRANDS.has(brand)) return "image/heif";
+    }
+    return null;
+}
+
+export type AttachmentRead =
+    | { ok: true; data: Buffer; mime: string }
+    | { ok: false; message: string };
+
+/**
+ * The configured attachments directory, or `undefined` when unconfined.
+ *
+ * Claude Desktop only substitutes a `${user_config.X}` template when the user
+ * actually fills the field in; an optional field left blank arrives as the
+ * literal template string. That is truthy, so without this guard every
+ * `.mcpb` install that skipped the directory prompt would fail to resolve it
+ * and the tool would be unusable. An unsubstituted template means "unset".
+ */
+export function attachmentsRoot(): string | undefined {
+    const root = process.env.LUNCHMONEY_ATTACHMENTS_DIR?.trim();
+    if (!root || root.includes("${user_config.")) return undefined;
+    return root;
+}
+
+/**
+ * Read a file the caller named, for upload as a transaction attachment.
+ *
+ * `file_path` reaches this server from an AI model, which may in turn be acting
+ * on untrusted content (a payee name, a note, a web page). Treat it as hostile:
+ *
+ * 1. If `LUNCHMONEY_ATTACHMENTS_DIR` is set, the path must resolve inside it.
+ *    The check runs after `realpath`, so `..` traversal and symlink escapes are
+ *    both caught. Unset means unconfined — fine for a desktop stdio server,
+ *    where the caller and the file owner are the same person, but deployments
+ *    that expose this server over HTTP should always set it.
+ * 2. Only regular files, so `/dev/*` and directories are rejected. The open is
+ *    non-blocking because a read-only `open(2)` on a FIFO blocks until a writer
+ *    appears — without `O_NONBLOCK` a caller could hang the request forever,
+ *    pin a libuv threadpool thread, and stop the server exiting cleanly.
+ * 3. Size is checked from `stat` before any bytes are buffered, so a huge file
+ *    can't exhaust memory on its way to being rejected.
+ * 4. The type comes from the leading bytes, checked before the rest of the file
+ *    is read. Credentials, keys, and dotenv files never make it into memory.
+ *
+ * Filesystem errors are logged to stderr but reported back to the caller
+ * generically — distinguishing ENOENT from EACCES would let a caller map out
+ * the host's filesystem one failed call at a time.
+ */
+export async function readAttachment(
+    filePath: string,
+): Promise<AttachmentRead> {
+    const unreadable = {
+        ok: false as const,
+        message: "file could not be read.",
+    };
+    const root = attachmentsRoot();
+
+    let resolved: string;
+    try {
+        resolved = await realpath(resolve(filePath));
+    } catch (error) {
+        console.error(`Failed to resolve attachment path: ${describe(error)}`);
+        return unreadable;
+    }
+
+    if (root) {
+        let base: string;
+        try {
+            base = await realpath(resolve(root));
+        } catch (error) {
+            console.error(
+                `Failed to resolve LUNCHMONEY_ATTACHMENTS_DIR: ${describe(error)}`,
+            );
+            return {
+                ok: false,
+                message: `the directory configured in LUNCHMONEY_ATTACHMENTS_DIR (${root}) could not be resolved.`,
+            };
+        }
+        if (resolved !== base && !resolved.startsWith(base + sep)) {
+            return {
+                ok: false,
+                message:
+                    "file_path resolves outside the directory configured in LUNCHMONEY_ATTACHMENTS_DIR.",
+            };
+        }
+    }
+
+    let handle;
+    try {
+        handle = await open(resolved, O_RDONLY | O_NONBLOCK);
+    } catch (error) {
+        console.error(`Failed to open attachment: ${describe(error)}`);
+        return unreadable;
+    }
+
+    try {
+        const stats = await handle.stat();
+        if (!stats.isFile()) {
+            return {
+                ok: false,
+                message: "file_path must point to a regular file.",
+            };
+        }
+        if (stats.size > MAX_ATTACHMENT_BYTES) {
+            return {
+                ok: false,
+                message: `file size ${stats.size} bytes exceeds maximum of ${MAX_ATTACHMENT_BYTES} bytes (10MB).`,
+            };
+        }
+
+        // Reading at an explicit position leaves the handle's own offset at 0,
+        // so the readFile() below still returns the whole file.
+        const header = Buffer.alloc(ATTACHMENT_HEADER_BYTES);
+        const { bytesRead } = await handle.read(
+            header,
+            0,
+            ATTACHMENT_HEADER_BYTES,
+            0,
+        );
+        const mime = sniffMimeType(header.subarray(0, bytesRead));
+        if (!mime) {
+            return {
+                ok: false,
+                message: `the file's contents are not a supported attachment type. Allowed types are: ${ALLOWED_ATTACHMENT_MIME_TYPES.join(", ")}`,
+            };
+        }
+
+        return { ok: true, data: await handle.readFile(), mime };
+    } catch (error) {
+        console.error(`Failed to read attachment: ${describe(error)}`);
+        return unreadable;
+    } finally {
+        await handle.close().catch(() => {});
+    }
+}
+
+function describe(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -1,5 +1,5 @@
-import { readFile } from "node:fs/promises";
-import { basename } from "node:path";
+import { open, realpath } from "node:fs/promises";
+import { basename, resolve, sep } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
@@ -11,14 +11,25 @@ import {
     errorResponse,
 } from "../api.js";
 
-const ALLOWED_ATTACHMENT_MIME_TYPES = new Set([
+const ALLOWED_ATTACHMENT_MIME_TYPES = [
     "image/jpeg",
     "image/png",
     "image/heic",
     "image/heif",
     "application/pdf",
-]);
+] as const;
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+
+// Enough to cover the longest signature we check: the ISO-BMFF `ftyp` box
+// header plus its major brand occupies the first 12 bytes.
+const ATTACHMENT_HEADER_BYTES = 16;
+const PNG_SIGNATURE = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+// ISO-BMFF major brands. HEIC and HEIF share a container; the brand decides
+// which of the two MIME types the LunchMoney API expects.
+const HEIC_BRANDS = new Set(["heic", "heix", "hevc", "hevx"]);
+const HEIF_BRANDS = new Set(["mif1", "msf1", "heim", "heis", "hevm", "hevs"]);
 
 const splitChildSchema = z.object({
     amount: z.coerce
@@ -728,7 +739,7 @@ export function registerTransactionTools(server: McpServer) {
         "attach_file_to_transaction",
         {
             description:
-                "Attach a local file (max 10MB) to a transaction. Allowed types: image/jpeg, image/png, image/heic, image/heif, application/pdf. The file is read from the local filesystem of the host running this MCP server.",
+                "Attach a local image or PDF receipt (max 10MB) to a transaction. Allowed types: image/jpeg, image/png, image/heic, image/heif, application/pdf. The file is read from the local filesystem of the host running this MCP server, and its type is determined from its actual contents — files that are not a real image or PDF are rejected. If LUNCHMONEY_ATTACHMENTS_DIR is set on the host, only files inside that directory can be attached.",
             inputSchema: {
                 transaction_id: z.coerce
                     .number()
@@ -736,13 +747,13 @@ export function registerTransactionTools(server: McpServer) {
                 file_path: z
                     .string()
                     .describe(
-                        "Absolute or relative path to the file on the local filesystem.",
+                        "Absolute or relative path to the receipt file on the local filesystem. Must be a regular file whose contents are a JPEG, PNG, HEIC, HEIF, or PDF. If the host sets LUNCHMONEY_ATTACHMENTS_DIR, the path must resolve inside that directory.",
                     ),
                 content_type: z
-                    .string()
+                    .enum(ALLOWED_ATTACHMENT_MIME_TYPES)
                     .optional()
                     .describe(
-                        "MIME type. If omitted, the server infers it from the file extension.",
+                        "Optional assertion of the file's MIME type. The server always determines the real type from the file contents; if this disagrees with it, the request is rejected. Omit unless you need that check.",
                     ),
                 notes: z
                     .string()
@@ -755,25 +766,26 @@ export function registerTransactionTools(server: McpServer) {
         },
         async ({ transaction_id, file_path, content_type, notes }) => {
             try {
-                const mime = content_type ?? inferMimeType(file_path);
-                if (!mime || !ALLOWED_ATTACHMENT_MIME_TYPES.has(mime)) {
-                    // The v2 API documents these as the only permitted types
-                    // but does not enforce the restriction server-side, so
-                    // we validate client-side to fail fast and prevent
-                    // orphaned attachments with type=unknown.
+                const file = await readAttachment(file_path);
+                if (!file.ok) {
                     return errorResponse(
-                        `Failed to attach file to transaction: file type ${mime ?? "unknown"} not allowed. Allowed types are: ${[...ALLOWED_ATTACHMENT_MIME_TYPES].join(", ")}`,
+                        `Failed to attach file to transaction: ${file.message}`,
                     );
                 }
 
-                const data = await readFile(file_path);
-                if (data.byteLength > MAX_ATTACHMENT_BYTES) {
+                // The caller may assert a type, but the file's own bytes are
+                // authoritative. A mismatch means the caller is confused about
+                // what it is uploading, so refuse rather than silently
+                // correcting it.
+                if (content_type !== undefined && content_type !== file.mime) {
                     return errorResponse(
-                        `Failed to attach file to transaction: file size ${data.byteLength} bytes exceeds maximum of ${MAX_ATTACHMENT_BYTES} bytes (10MB).`,
+                        `Failed to attach file to transaction: declared content_type ${content_type} does not match the file's actual type ${file.mime}.`,
                     );
                 }
 
-                const blob = new Blob([new Uint8Array(data)], { type: mime });
+                const blob = new Blob([new Uint8Array(file.data)], {
+                    type: file.mime,
+                });
 
                 const formData = new FormData();
                 formData.append("file", blob, basename(file_path));
@@ -873,21 +885,154 @@ export function registerTransactionTools(server: McpServer) {
     );
 }
 
-function inferMimeType(path: string): string | null {
-    const ext = path.toLowerCase().split(".").pop();
-    switch (ext) {
-        case "jpg":
-        case "jpeg":
-            return "image/jpeg";
-        case "png":
-            return "image/png";
-        case "heic":
-            return "image/heic";
-        case "heif":
-            return "image/heif";
-        case "pdf":
-            return "application/pdf";
-        default:
-            return null;
+/**
+ * Identify an attachment by its leading bytes.
+ *
+ * The file extension and any caller-supplied MIME type are both untrusted —
+ * only the contents decide. Returns `null` for anything that is not one of the
+ * types the LunchMoney attachments endpoint accepts, which is what stops this
+ * tool from being used to read arbitrary non-media files off the host.
+ */
+function sniffMimeType(header: Buffer): string | null {
+    if (
+        header.length >= 3 &&
+        header[0] === 0xff &&
+        header[1] === 0xd8 &&
+        header[2] === 0xff
+    ) {
+        return "image/jpeg";
     }
+    if (header.length >= 8 && header.subarray(0, 8).equals(PNG_SIGNATURE)) {
+        return "image/png";
+    }
+    if (
+        header.length >= 5 &&
+        header.subarray(0, 5).toString("latin1") === "%PDF-"
+    ) {
+        return "application/pdf";
+    }
+    if (
+        header.length >= 12 &&
+        header.subarray(4, 8).toString("latin1") === "ftyp"
+    ) {
+        const brand = header.subarray(8, 12).toString("latin1");
+        if (HEIC_BRANDS.has(brand)) return "image/heic";
+        if (HEIF_BRANDS.has(brand)) return "image/heif";
+    }
+    return null;
+}
+
+type AttachmentRead =
+    | { ok: true; data: Buffer; mime: string }
+    | { ok: false; message: string };
+
+/**
+ * Read a file the caller named, for upload as a transaction attachment.
+ *
+ * `file_path` reaches this server from an AI model, which may in turn be acting
+ * on untrusted content (a payee name, a note, a web page). Treat it as hostile:
+ *
+ * 1. If `LUNCHMONEY_ATTACHMENTS_DIR` is set, the path must resolve inside it.
+ *    The check runs after `realpath`, so `..` traversal and symlink escapes are
+ *    both caught. Unset means unconfined — fine for a desktop stdio server,
+ *    where the caller and the file owner are the same person, but deployments
+ *    that expose this server over HTTP should always set it.
+ * 2. Only regular files, so `/dev/*` and FIFOs can't be opened.
+ * 3. Size is checked from `stat` before any bytes are buffered, so a huge file
+ *    can't exhaust memory on its way to being rejected.
+ * 4. The type comes from the leading bytes, checked before the rest of the file
+ *    is read. Credentials, keys, and `.env` files never make it into memory.
+ *
+ * Filesystem errors are logged to stderr but reported back to the caller
+ * generically — distinguishing ENOENT from EACCES would let a caller map out
+ * the host's filesystem one failed call at a time.
+ */
+async function readAttachment(filePath: string): Promise<AttachmentRead> {
+    const unreadable = {
+        ok: false as const,
+        message: "file could not be read.",
+    };
+    const root = process.env.LUNCHMONEY_ATTACHMENTS_DIR;
+
+    let resolved: string;
+    try {
+        resolved = await realpath(resolve(filePath));
+    } catch (error) {
+        console.error(`Failed to resolve attachment path: ${describe(error)}`);
+        return unreadable;
+    }
+
+    if (root) {
+        let base: string;
+        try {
+            base = await realpath(resolve(root));
+        } catch (error) {
+            console.error(
+                `Failed to resolve LUNCHMONEY_ATTACHMENTS_DIR: ${describe(error)}`,
+            );
+            return {
+                ok: false,
+                message: `the directory configured in LUNCHMONEY_ATTACHMENTS_DIR (${root}) could not be resolved.`,
+            };
+        }
+        if (resolved !== base && !resolved.startsWith(base + sep)) {
+            return {
+                ok: false,
+                message:
+                    "file_path resolves outside the directory configured in LUNCHMONEY_ATTACHMENTS_DIR.",
+            };
+        }
+    }
+
+    let handle;
+    try {
+        handle = await open(resolved, "r");
+    } catch (error) {
+        console.error(`Failed to open attachment: ${describe(error)}`);
+        return unreadable;
+    }
+
+    try {
+        const stats = await handle.stat();
+        if (!stats.isFile()) {
+            return {
+                ok: false,
+                message: "file_path must point to a regular file.",
+            };
+        }
+        if (stats.size > MAX_ATTACHMENT_BYTES) {
+            return {
+                ok: false,
+                message: `file size ${stats.size} bytes exceeds maximum of ${MAX_ATTACHMENT_BYTES} bytes (10MB).`,
+            };
+        }
+
+        // Reading at an explicit position leaves the handle's own offset at 0,
+        // so the readFile() below still returns the whole file.
+        const header = Buffer.alloc(ATTACHMENT_HEADER_BYTES);
+        const { bytesRead } = await handle.read(
+            header,
+            0,
+            ATTACHMENT_HEADER_BYTES,
+            0,
+        );
+        const mime = sniffMimeType(header.subarray(0, bytesRead));
+        if (!mime) {
+            return {
+                ok: false,
+                message: `the file's contents are not a supported attachment type. Allowed types are: ${ALLOWED_ATTACHMENT_MIME_TYPES.join(", ")}`,
+            };
+        }
+
+        return { ok: true, data: await handle.readFile(), mime };
+    } catch (error) {
+        console.error(`Failed to read attachment: ${describe(error)}`);
+        return unreadable;
+    } finally {
+        await handle.close().catch(() => {});
+    }
+}
+
+function describe(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
 }

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -1,5 +1,8 @@
+import { constants } from "node:fs";
 import { open, realpath } from "node:fs/promises";
 import { basename, resolve, sep } from "node:path";
+
+const { O_RDONLY, O_NONBLOCK } = constants;
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
@@ -20,16 +23,21 @@ const ALLOWED_ATTACHMENT_MIME_TYPES = [
 ] as const;
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 
-// Enough to cover the longest signature we check: the ISO-BMFF `ftyp` box
-// header plus its major brand occupies the first 12 bytes.
-const ATTACHMENT_HEADER_BYTES = 16;
+// The image signatures all sit in the first 12 bytes, but the PDF spec allows
+// junk before `%PDF-` and conforming readers scan the first 1024 bytes for it,
+// so the window has to be wide enough to match what real scanners emit.
+const ATTACHMENT_HEADER_BYTES = 1024;
 const PNG_SIGNATURE = Buffer.from([
     0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
 ]);
 // ISO-BMFF major brands. HEIC and HEIF share a container; the brand decides
-// which of the two MIME types the LunchMoney API expects.
+// which of the two MIME types the LunchMoney API expects. Plenty of real
+// `.HEIC` files (iOS among them) carry `mif1` as the major brand and list
+// `heic` only as a compatible brand, so the two are treated as interchangeable
+// when checking a caller's `content_type` assertion.
 const HEIC_BRANDS = new Set(["heic", "heix", "hevc", "hevx"]);
 const HEIF_BRANDS = new Set(["mif1", "msf1", "heim", "heis", "hevm", "hevs"]);
+const HEIF_FAMILY = new Set(["image/heic", "image/heif"]);
 
 const splitChildSchema = z.object({
     amount: z.coerce
@@ -776,8 +784,17 @@ export function registerTransactionTools(server: McpServer) {
                 // The caller may assert a type, but the file's own bytes are
                 // authoritative. A mismatch means the caller is confused about
                 // what it is uploading, so refuse rather than silently
-                // correcting it.
-                if (content_type !== undefined && content_type !== file.mime) {
+                // correcting it. HEIC and HEIF are exempt: the major brand
+                // does not reliably distinguish them, so a caller calling an
+                // `mif1` file `image/heic` is right, not confused.
+                const sameFamily =
+                    HEIF_FAMILY.has(file.mime) &&
+                    HEIF_FAMILY.has(content_type ?? "");
+                if (
+                    content_type !== undefined &&
+                    content_type !== file.mime &&
+                    !sameFamily
+                ) {
                     return errorResponse(
                         `Failed to attach file to transaction: declared content_type ${content_type} does not match the file's actual type ${file.mime}.`,
                     );
@@ -905,10 +922,11 @@ function sniffMimeType(header: Buffer): string | null {
     if (header.length >= 8 && header.subarray(0, 8).equals(PNG_SIGNATURE)) {
         return "image/png";
     }
-    if (
-        header.length >= 5 &&
-        header.subarray(0, 5).toString("latin1") === "%PDF-"
-    ) {
+    // Not anchored at offset 0: the PDF spec tolerates bytes before the header
+    // and conforming readers scan for it, as do the scanners that produce some
+    // receipts. Files of the kind this check exists to exclude — keys, `.env`,
+    // `/etc/passwd` — do not contain this marker, so the wider window is free.
+    if (header.includes("%PDF-", 0, "latin1")) {
         return "application/pdf";
     }
     if (
@@ -937,7 +955,10 @@ type AttachmentRead =
  *    both caught. Unset means unconfined — fine for a desktop stdio server,
  *    where the caller and the file owner are the same person, but deployments
  *    that expose this server over HTTP should always set it.
- * 2. Only regular files, so `/dev/*` and FIFOs can't be opened.
+ * 2. Only regular files, so `/dev/*` and directories are rejected. The open is
+ *    non-blocking because a read-only `open(2)` on a FIFO blocks until a writer
+ *    appears — without `O_NONBLOCK` a caller could hang the request forever,
+ *    pin a libuv threadpool thread, and stop the server exiting cleanly.
  * 3. Size is checked from `stat` before any bytes are buffered, so a huge file
  *    can't exhaust memory on its way to being rejected.
  * 4. The type comes from the leading bytes, checked before the rest of the file
@@ -952,7 +973,7 @@ async function readAttachment(filePath: string): Promise<AttachmentRead> {
         ok: false as const,
         message: "file could not be read.",
     };
-    const root = process.env.LUNCHMONEY_ATTACHMENTS_DIR;
+    const root = attachmentsRoot();
 
     let resolved: string;
     try {
@@ -986,7 +1007,7 @@ async function readAttachment(filePath: string): Promise<AttachmentRead> {
 
     let handle;
     try {
-        handle = await open(resolved, "r");
+        handle = await open(resolved, O_RDONLY | O_NONBLOCK);
     } catch (error) {
         console.error(`Failed to open attachment: ${describe(error)}`);
         return unreadable;
@@ -1031,6 +1052,21 @@ async function readAttachment(filePath: string): Promise<AttachmentRead> {
     } finally {
         await handle.close().catch(() => {});
     }
+}
+
+/**
+ * The configured attachments directory, or `undefined` when unconfined.
+ *
+ * Claude Desktop only substitutes a `${user_config.X}` template when the user
+ * actually fills the field in; an optional field left blank arrives as the
+ * literal template string. That is truthy, so without this guard every
+ * `.mcpb` install that skipped the directory prompt would fail to resolve it
+ * and the tool would be unusable. An unsubstituted template means "unset".
+ */
+function attachmentsRoot(): string | undefined {
+    const root = process.env.LUNCHMONEY_ATTACHMENTS_DIR?.trim();
+    if (!root || root.includes("${user_config.")) return undefined;
+    return root;
 }
 
 function describe(error: unknown): string {

--- a/src/tools/transactions.ts
+++ b/src/tools/transactions.ts
@@ -1,8 +1,4 @@
-import { constants } from "node:fs";
-import { open, realpath } from "node:fs/promises";
-import { basename, resolve, sep } from "node:path";
-
-const { O_RDONLY, O_NONBLOCK } = constants;
+import { basename } from "node:path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
@@ -13,31 +9,11 @@ import {
     catchError,
     errorResponse,
 } from "../api.js";
-
-const ALLOWED_ATTACHMENT_MIME_TYPES = [
-    "image/jpeg",
-    "image/png",
-    "image/heic",
-    "image/heif",
-    "application/pdf",
-] as const;
-const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
-
-// The image signatures all sit in the first 12 bytes, but the PDF spec allows
-// junk before `%PDF-` and conforming readers scan the first 1024 bytes for it,
-// so the window has to be wide enough to match what real scanners emit.
-const ATTACHMENT_HEADER_BYTES = 1024;
-const PNG_SIGNATURE = Buffer.from([
-    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
-]);
-// ISO-BMFF major brands. HEIC and HEIF share a container; the brand decides
-// which of the two MIME types the LunchMoney API expects. Plenty of real
-// `.HEIC` files (iOS among them) carry `mif1` as the major brand and list
-// `heic` only as a compatible brand, so the two are treated as interchangeable
-// when checking a caller's `content_type` assertion.
-const HEIC_BRANDS = new Set(["heic", "heix", "hevc", "hevx"]);
-const HEIF_BRANDS = new Set(["mif1", "msf1", "heim", "heis", "hevm", "hevs"]);
-const HEIF_FAMILY = new Set(["image/heic", "image/heif"]);
+import {
+    ALLOWED_ATTACHMENT_MIME_TYPES,
+    contentTypeMatches,
+    readAttachment,
+} from "../attachments.js";
 
 const splitChildSchema = z.object({
     amount: z.coerce
@@ -784,16 +760,10 @@ export function registerTransactionTools(server: McpServer) {
                 // The caller may assert a type, but the file's own bytes are
                 // authoritative. A mismatch means the caller is confused about
                 // what it is uploading, so refuse rather than silently
-                // correcting it. HEIC and HEIF are exempt: the major brand
-                // does not reliably distinguish them, so a caller calling an
-                // `mif1` file `image/heic` is right, not confused.
-                const sameFamily =
-                    HEIF_FAMILY.has(file.mime) &&
-                    HEIF_FAMILY.has(content_type ?? "");
+                // correcting it.
                 if (
                     content_type !== undefined &&
-                    content_type !== file.mime &&
-                    !sameFamily
+                    !contentTypeMatches(content_type, file.mime)
                 ) {
                     return errorResponse(
                         `Failed to attach file to transaction: declared content_type ${content_type} does not match the file's actual type ${file.mime}.`,
@@ -900,175 +870,4 @@ export function registerTransactionTools(server: McpServer) {
             }
         },
     );
-}
-
-/**
- * Identify an attachment by its leading bytes.
- *
- * The file extension and any caller-supplied MIME type are both untrusted —
- * only the contents decide. Returns `null` for anything that is not one of the
- * types the LunchMoney attachments endpoint accepts, which is what stops this
- * tool from being used to read arbitrary non-media files off the host.
- */
-function sniffMimeType(header: Buffer): string | null {
-    if (
-        header.length >= 3 &&
-        header[0] === 0xff &&
-        header[1] === 0xd8 &&
-        header[2] === 0xff
-    ) {
-        return "image/jpeg";
-    }
-    if (header.length >= 8 && header.subarray(0, 8).equals(PNG_SIGNATURE)) {
-        return "image/png";
-    }
-    // Not anchored at offset 0: the PDF spec tolerates bytes before the header
-    // and conforming readers scan for it, as do the scanners that produce some
-    // receipts. Files of the kind this check exists to exclude — keys, `.env`,
-    // `/etc/passwd` — do not contain this marker, so the wider window is free.
-    if (header.includes("%PDF-", 0, "latin1")) {
-        return "application/pdf";
-    }
-    if (
-        header.length >= 12 &&
-        header.subarray(4, 8).toString("latin1") === "ftyp"
-    ) {
-        const brand = header.subarray(8, 12).toString("latin1");
-        if (HEIC_BRANDS.has(brand)) return "image/heic";
-        if (HEIF_BRANDS.has(brand)) return "image/heif";
-    }
-    return null;
-}
-
-type AttachmentRead =
-    | { ok: true; data: Buffer; mime: string }
-    | { ok: false; message: string };
-
-/**
- * Read a file the caller named, for upload as a transaction attachment.
- *
- * `file_path` reaches this server from an AI model, which may in turn be acting
- * on untrusted content (a payee name, a note, a web page). Treat it as hostile:
- *
- * 1. If `LUNCHMONEY_ATTACHMENTS_DIR` is set, the path must resolve inside it.
- *    The check runs after `realpath`, so `..` traversal and symlink escapes are
- *    both caught. Unset means unconfined — fine for a desktop stdio server,
- *    where the caller and the file owner are the same person, but deployments
- *    that expose this server over HTTP should always set it.
- * 2. Only regular files, so `/dev/*` and directories are rejected. The open is
- *    non-blocking because a read-only `open(2)` on a FIFO blocks until a writer
- *    appears — without `O_NONBLOCK` a caller could hang the request forever,
- *    pin a libuv threadpool thread, and stop the server exiting cleanly.
- * 3. Size is checked from `stat` before any bytes are buffered, so a huge file
- *    can't exhaust memory on its way to being rejected.
- * 4. The type comes from the leading bytes, checked before the rest of the file
- *    is read. Credentials, keys, and `.env` files never make it into memory.
- *
- * Filesystem errors are logged to stderr but reported back to the caller
- * generically — distinguishing ENOENT from EACCES would let a caller map out
- * the host's filesystem one failed call at a time.
- */
-async function readAttachment(filePath: string): Promise<AttachmentRead> {
-    const unreadable = {
-        ok: false as const,
-        message: "file could not be read.",
-    };
-    const root = attachmentsRoot();
-
-    let resolved: string;
-    try {
-        resolved = await realpath(resolve(filePath));
-    } catch (error) {
-        console.error(`Failed to resolve attachment path: ${describe(error)}`);
-        return unreadable;
-    }
-
-    if (root) {
-        let base: string;
-        try {
-            base = await realpath(resolve(root));
-        } catch (error) {
-            console.error(
-                `Failed to resolve LUNCHMONEY_ATTACHMENTS_DIR: ${describe(error)}`,
-            );
-            return {
-                ok: false,
-                message: `the directory configured in LUNCHMONEY_ATTACHMENTS_DIR (${root}) could not be resolved.`,
-            };
-        }
-        if (resolved !== base && !resolved.startsWith(base + sep)) {
-            return {
-                ok: false,
-                message:
-                    "file_path resolves outside the directory configured in LUNCHMONEY_ATTACHMENTS_DIR.",
-            };
-        }
-    }
-
-    let handle;
-    try {
-        handle = await open(resolved, O_RDONLY | O_NONBLOCK);
-    } catch (error) {
-        console.error(`Failed to open attachment: ${describe(error)}`);
-        return unreadable;
-    }
-
-    try {
-        const stats = await handle.stat();
-        if (!stats.isFile()) {
-            return {
-                ok: false,
-                message: "file_path must point to a regular file.",
-            };
-        }
-        if (stats.size > MAX_ATTACHMENT_BYTES) {
-            return {
-                ok: false,
-                message: `file size ${stats.size} bytes exceeds maximum of ${MAX_ATTACHMENT_BYTES} bytes (10MB).`,
-            };
-        }
-
-        // Reading at an explicit position leaves the handle's own offset at 0,
-        // so the readFile() below still returns the whole file.
-        const header = Buffer.alloc(ATTACHMENT_HEADER_BYTES);
-        const { bytesRead } = await handle.read(
-            header,
-            0,
-            ATTACHMENT_HEADER_BYTES,
-            0,
-        );
-        const mime = sniffMimeType(header.subarray(0, bytesRead));
-        if (!mime) {
-            return {
-                ok: false,
-                message: `the file's contents are not a supported attachment type. Allowed types are: ${ALLOWED_ATTACHMENT_MIME_TYPES.join(", ")}`,
-            };
-        }
-
-        return { ok: true, data: await handle.readFile(), mime };
-    } catch (error) {
-        console.error(`Failed to read attachment: ${describe(error)}`);
-        return unreadable;
-    } finally {
-        await handle.close().catch(() => {});
-    }
-}
-
-/**
- * The configured attachments directory, or `undefined` when unconfined.
- *
- * Claude Desktop only substitutes a `${user_config.X}` template when the user
- * actually fills the field in; an optional field left blank arrives as the
- * literal template string. That is truthy, so without this guard every
- * `.mcpb` install that skipped the directory prompt would fail to resolve it
- * and the tool would be unusable. An unsubstituted template means "unset".
- */
-function attachmentsRoot(): string | undefined {
-    const root = process.env.LUNCHMONEY_ATTACHMENTS_DIR?.trim();
-    if (!root || root.includes("${user_config.")) return undefined;
-    return root;
-}
-
-function describe(error: unknown): string {
-    return error instanceof Error ? error.message : String(error);
 }

--- a/test/attachments.confinement.test.mjs
+++ b/test/attachments.confinement.test.mjs
@@ -1,0 +1,247 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+
+import { readAttachment, attachmentsRoot } from "../build/attachments.js";
+import {
+    sandbox,
+    FIXTURES,
+    withAttachmentsDir,
+    muteStderr,
+} from "./helpers.mjs";
+
+describe("attachment path confinement", () => {
+    let box;
+
+    beforeEach(() => {
+        box = sandbox();
+    });
+
+    afterEach(() => {
+        box.cleanup();
+    });
+
+    describe("unconfined mode (LUNCHMONEY_ATTACHMENTS_DIR unset)", () => {
+        it("reads a genuine PNG from anywhere on disk and returns its exact bytes", async () => {
+            const png = box.file("outside/anywhere.png", FIXTURES.png);
+
+            const result = await withAttachmentsDir(undefined, () =>
+                readAttachment(png),
+            );
+
+            assert.equal(result.ok, true);
+            assert.equal(result.mime, "image/png");
+            assert.deepEqual(result.data, FIXTURES.png);
+        });
+    });
+
+    describe("confined mode (LUNCHMONEY_ATTACHMENTS_DIR set)", () => {
+        it("reads a genuine PNG that lives directly inside the vault", async () => {
+            const png = box.file("vault/receipt.png", FIXTURES.png);
+
+            const result = await withAttachmentsDir(box.vault, () =>
+                readAttachment(png),
+            );
+
+            assert.equal(result.ok, true);
+            assert.equal(result.mime, "image/png");
+            assert.deepEqual(result.data, FIXTURES.png);
+        });
+
+        it("reads a genuine PNG from a nested subdirectory of the vault", async () => {
+            box.dir("vault/2026/january");
+            const png = box.file(
+                join("vault", "2026", "january", "receipt.png"),
+                FIXTURES.png,
+            );
+
+            const result = await withAttachmentsDir(box.vault, () =>
+                readAttachment(png),
+            );
+
+            assert.equal(result.ok, true);
+            assert.equal(result.mime, "image/png");
+            assert.deepEqual(result.data, FIXTURES.png);
+        });
+
+        it("rejects an absolute path to a file outside the vault", async () => {
+            const secret = box.file("outside/secret.png", FIXTURES.png);
+
+            const result = await withAttachmentsDir(box.vault, () =>
+                readAttachment(secret),
+            );
+
+            assert.equal(result.ok, false);
+            assert.match(
+                result.message,
+                /resolves outside the directory configured in LUNCHMONEY_ATTACHMENTS_DIR/,
+            );
+        });
+
+        it("rejects `..` traversal that climbs out of the vault", async () => {
+            box.file("outside/secret.png", FIXTURES.png);
+            const traversal = join(box.vault, "..", "outside", "secret.png");
+
+            const result = await withAttachmentsDir(box.vault, () =>
+                readAttachment(traversal),
+            );
+
+            assert.equal(result.ok, false);
+            assert.match(
+                result.message,
+                /resolves outside the directory configured in LUNCHMONEY_ATTACHMENTS_DIR/,
+            );
+        });
+
+        it("rejects a symlink inside the vault whose target is outside it, even though the target is a genuine PNG", async () => {
+            // The target really is a valid attachment, so a rejection here can
+            // only come from post-realpath containment, not content sniffing.
+            const target = box.file("outside/secret.png", FIXTURES.png);
+            const link = box.link("vault/innocent.png", target);
+
+            const result = await withAttachmentsDir(box.vault, () =>
+                readAttachment(link),
+            );
+
+            assert.equal(result.ok, false);
+            assert.match(
+                result.message,
+                /resolves outside the directory configured in LUNCHMONEY_ATTACHMENTS_DIR/,
+            );
+        });
+
+        it("rejects a prefix-sibling directory such as `<vault>-evil` that a naive startsWith(base) would allow", async () => {
+            box.dir("vault-evil");
+            const sneaky = box.file("vault-evil/secret.png", FIXTURES.png);
+            assert.ok(
+                sneaky.startsWith(box.vault),
+                "fixture must share a string prefix with the vault path",
+            );
+
+            const result = await withAttachmentsDir(box.vault, () =>
+                readAttachment(sneaky),
+            );
+
+            assert.equal(result.ok, false);
+            assert.match(
+                result.message,
+                /resolves outside the directory configured in LUNCHMONEY_ATTACHMENTS_DIR/,
+            );
+        });
+
+        it("fails with a message naming LUNCHMONEY_ATTACHMENTS_DIR when the configured directory does not exist", async () => {
+            const png = box.file("vault/receipt.png", FIXTURES.png);
+            const missing = join(box.root, "no-such-vault");
+
+            const restore = muteStderr();
+            try {
+                const result = await withAttachmentsDir(missing, () =>
+                    readAttachment(png),
+                );
+
+                assert.equal(result.ok, false);
+                assert.match(result.message, /LUNCHMONEY_ATTACHMENTS_DIR/);
+                assert.match(result.message, /could not be resolved/);
+            } finally {
+                restore();
+            }
+        });
+    });
+
+    describe("filesystem error disclosure", () => {
+        it("reports a nonexistent path generically and leaks no errno detail that could be used to enumerate the filesystem", async () => {
+            const missing = join(box.root, "does-not-exist.png");
+
+            const restore = muteStderr();
+            try {
+                const result = await withAttachmentsDir(undefined, () =>
+                    readAttachment(missing),
+                );
+
+                assert.equal(result.ok, false);
+                assert.equal(result.message, "file could not be read.");
+                assert.doesNotMatch(
+                    result.message,
+                    /ENOENT|EACCES|no such file/i,
+                );
+            } finally {
+                restore();
+            }
+        });
+    });
+});
+
+describe("attachmentsRoot()", () => {
+    it("returns undefined when LUNCHMONEY_ATTACHMENTS_DIR is unset", async () => {
+        await withAttachmentsDir(undefined, () => {
+            assert.equal(attachmentsRoot(), undefined);
+        });
+    });
+
+    it("treats an empty string as unset", async () => {
+        await withAttachmentsDir("", () => {
+            assert.equal(attachmentsRoot(), undefined);
+        });
+    });
+
+    it("treats a whitespace-only value as unset", async () => {
+        await withAttachmentsDir("   \t  ", () => {
+            assert.equal(attachmentsRoot(), undefined);
+        });
+    });
+
+    it("treats an unsubstituted MCPB user_config template as unset", async () => {
+        await withAttachmentsDir(
+            "${user_config.LUNCHMONEY_ATTACHMENTS_DIR}",
+            () => {
+                assert.equal(attachmentsRoot(), undefined);
+            },
+        );
+    });
+
+    it("returns a normal path unchanged", async () => {
+        await withAttachmentsDir("/srv/receipts", () => {
+            assert.equal(attachmentsRoot(), "/srv/receipts");
+        });
+    });
+
+    it("trims surrounding whitespace from a configured path", async () => {
+        await withAttachmentsDir("  /srv/receipts \n", () => {
+            assert.equal(attachmentsRoot(), "/srv/receipts");
+        });
+    });
+});
+
+describe("unsubstituted MCPB template behaves as unconfined", () => {
+    let box;
+
+    beforeEach(() => {
+        box = sandbox();
+    });
+
+    afterEach(() => {
+        box.cleanup();
+    });
+
+    it("reads a genuine PNG outside any vault instead of failing to resolve the template as a directory", async () => {
+        const png = box.file("outside/receipt.png", FIXTURES.png);
+
+        const restore = muteStderr();
+        try {
+            const result = await withAttachmentsDir(
+                "${user_config.LUNCHMONEY_ATTACHMENTS_DIR}",
+                () => readAttachment(png),
+            );
+
+            assert.equal(
+                result.ok,
+                true,
+                `expected success, got: ${result.message}`,
+            );
+            assert.equal(result.mime, "image/png");
+            assert.deepEqual(result.data, FIXTURES.png);
+        } finally {
+            restore();
+        }
+    });
+});

--- a/test/attachments.resources.test.mjs
+++ b/test/attachments.resources.test.mjs
@@ -1,0 +1,332 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+    closeSync,
+    existsSync,
+    openSync,
+    readFileSync,
+    writeSync,
+} from "node:fs";
+
+import { readAttachment, MAX_ATTACHMENT_BYTES } from "../build/attachments.js";
+import {
+    sandbox,
+    FIXTURES,
+    withAttachmentsDir,
+    muteStderr,
+} from "./helpers.mjs";
+
+/**
+ * How long a call is allowed to take before the test calls it a hang.
+ *
+ * Every path exercised here returns in single-digit milliseconds when the
+ * hardening is in place, so 5s is pure headroom for a loaded CI box.
+ */
+const HANG_TIMEOUT_MS = 5000;
+const TIMED_OUT = Symbol("timed out");
+
+/**
+ * Race `promise` against a timer and fail if the timer wins.
+ *
+ * The tests below feed `readAttachment` paths that used to make it block
+ * forever (a FIFO) or read without bound (`/dev/zero`). Awaiting those directly
+ * would hang the whole suite — and, in the FIFO case, hang it in a way `node
+ * --test` cannot recover from, because the blocked `open(2)` pins a libuv
+ * threadpool thread and the process will not exit. Racing turns a regression
+ * into a fast, legible assertion failure instead.
+ *
+ * Confirmed by mutation: dropping `O_NONBLOCK` from the open in
+ * `src/attachments.ts` fails both FIFO tests at ~5s each, as intended. The
+ * runner then still cannot exit — not even with `--test-force-exit`, since the
+ * pinned thread outlives the test. So that particular regression surfaces as
+ * "failures reported, then CI hangs to its job timeout" rather than a clean red
+ * run. The failures are printed first, which is what matters for diagnosis.
+ */
+async function withinTimeout(promise, label) {
+    let timer;
+    const guard = new Promise((resolve) => {
+        timer = setTimeout(() => resolve(TIMED_OUT), HANG_TIMEOUT_MS);
+        timer.unref?.();
+    });
+    try {
+        const result = await Promise.race([promise, guard]);
+        assert.notEqual(
+            result,
+            TIMED_OUT,
+            `${label}: readAttachment did not return within ${HANG_TIMEOUT_MS}ms — it hung`,
+        );
+        return result;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+describe("attachment file-type guards", () => {
+    let box;
+
+    beforeEach(() => {
+        box = sandbox();
+    });
+
+    afterEach(() => {
+        box.cleanup();
+    });
+
+    it("rejects a FIFO instead of blocking forever waiting for a writer", async () => {
+        // The regression this guards: a read-only open(2) on a FIFO blocks
+        // until some other process opens the write end. Without
+        // O_RDONLY | O_NONBLOCK this call never returns, the request hangs
+        // forever, and the pinned libuv threadpool thread stops the server
+        // process from exiting at all. The isFile() check is no help on its
+        // own — it only runs after the open that never completes.
+        const fifo = box.fifo("outside/pipe.png");
+
+        const restore = muteStderr();
+        try {
+            const result = await withinTimeout(
+                withAttachmentsDir(undefined, () => readAttachment(fifo)),
+                "FIFO (unconfined)",
+            );
+
+            assert.equal(result.ok, false);
+            assert.match(result.message, /must point to a regular file/);
+        } finally {
+            restore();
+        }
+    });
+
+    it("rejects a FIFO created inside the configured attachments directory, where confinement offers no protection", async () => {
+        // Path confinement cannot defend against this: anyone who can drop a
+        // file in the attachments directory can drop a FIFO there too, and it
+        // passes every containment check before reaching the open.
+        const fifo = box.fifo("vault/receipt.png");
+
+        const restore = muteStderr();
+        try {
+            const result = await withinTimeout(
+                withAttachmentsDir(box.vault, () => readAttachment(fifo)),
+                "FIFO (inside vault)",
+            );
+
+            assert.equal(result.ok, false);
+            assert.match(result.message, /must point to a regular file/);
+        } finally {
+            restore();
+        }
+    });
+
+    it("rejects the /dev/zero character device without hanging or buffering it", async (t) => {
+        // The regression this guards: the 10MB cap used to be applied after
+        // readFile() had already buffered the file, so /dev/zero — infinite,
+        // and reporting size 0 — grew the heap without bound (~11GB RSS in
+        // ten seconds). Rejecting non-regular files off the stat is what stops
+        // a single byte of it being read.
+        if (!existsSync("/dev/zero")) {
+            t.skip("/dev/zero is not present on this platform");
+            return;
+        }
+
+        const restore = muteStderr();
+        try {
+            const result = await withinTimeout(
+                withAttachmentsDir(undefined, () =>
+                    readAttachment("/dev/zero"),
+                ),
+                "/dev/zero",
+            );
+
+            assert.equal(result.ok, false);
+            assert.match(result.message, /must point to a regular file/);
+        } finally {
+            restore();
+        }
+    });
+
+    it("rejects a directory path with the regular-file message rather than throwing", async () => {
+        const dir = box.dir("outside/receipts");
+
+        const restore = muteStderr();
+        try {
+            const result = await withAttachmentsDir(undefined, () =>
+                readAttachment(dir),
+            );
+
+            assert.equal(result.ok, false);
+            assert.match(result.message, /must point to a regular file/);
+        } finally {
+            restore();
+        }
+    });
+
+    it("resolves and reads a symlink that points at a genuine regular file", async () => {
+        // The non-regular-file guard must not cost legitimate symlink use:
+        // stat() on the handle follows the link, so the target's mode decides.
+        const target = box.file("outside/receipt.png", FIXTURES.png);
+        const link = box.link("outside/latest.png", target);
+
+        const result = await withAttachmentsDir(undefined, () =>
+            readAttachment(link),
+        );
+
+        assert.equal(
+            result.ok,
+            true,
+            `expected success, got: ${result.message}`,
+        );
+        assert.equal(result.mime, "image/png");
+        assert.deepEqual(result.data, FIXTURES.png);
+    });
+
+    it("rejects an empty file as an unsupported type rather than throwing on a zero-byte header read", async () => {
+        const empty = box.file("outside/empty.png", Buffer.alloc(0));
+
+        const restore = muteStderr();
+        try {
+            const result = await withAttachmentsDir(undefined, () =>
+                readAttachment(empty),
+            );
+
+            assert.equal(result.ok, false);
+            assert.match(result.message, /not a supported attachment type/);
+        } finally {
+            restore();
+        }
+    });
+});
+
+describe("attachment size cap", () => {
+    let box;
+
+    beforeEach(() => {
+        box = sandbox();
+    });
+
+    afterEach(() => {
+        box.cleanup();
+    });
+
+    it("rejects a file one byte over the maximum, from stat, before reading any of it", async () => {
+        // Sparse, so this costs no disk and no time. The file opens with a
+        // genuine PNG signature, which means content sniffing alone would
+        // happily accept it — only a size check performed on the stat can
+        // produce the rejection asserted below.
+        const oversize = box.sparse(
+            "outside/huge.png",
+            MAX_ATTACHMENT_BYTES + 1,
+        );
+        const fd = openSync(oversize, "r+");
+        try {
+            writeSync(fd, FIXTURES.png, 0, FIXTURES.png.length, 0);
+        } finally {
+            closeSync(fd);
+        }
+
+        const restore = muteStderr();
+        try {
+            const result = await withinTimeout(
+                withAttachmentsDir(undefined, () => readAttachment(oversize)),
+                "oversized sparse file",
+            );
+
+            assert.equal(result.ok, false);
+            assert.match(result.message, /file size/);
+            assert.match(
+                result.message,
+                new RegExp(String(MAX_ATTACHMENT_BYTES + 1)),
+                "message should report the file's actual size",
+            );
+            assert.match(
+                result.message,
+                new RegExp(String(MAX_ATTACHMENT_BYTES)),
+                "message should report the maximum",
+            );
+            // The size check has to run before the content check, so a valid
+            // PNG prefix must not change the verdict or the wording.
+            assert.doesNotMatch(
+                result.message,
+                /not a supported attachment type/,
+            );
+        } finally {
+            restore();
+        }
+    });
+
+    it("accepts a genuine PNG comfortably under the maximum", async () => {
+        const png = box.file("outside/small.png", FIXTURES.png);
+        assert.ok(
+            FIXTURES.png.length < MAX_ATTACHMENT_BYTES,
+            "fixture must sit under the cap for this boundary to mean anything",
+        );
+
+        const result = await withAttachmentsDir(undefined, () =>
+            readAttachment(png),
+        );
+
+        assert.equal(
+            result.ok,
+            true,
+            `expected success, got: ${result.message}`,
+        );
+        assert.equal(result.mime, "image/png");
+        assert.deepEqual(result.data, FIXTURES.png);
+    });
+});
+
+describe("attachment payload integrity", () => {
+    let box;
+
+    beforeEach(() => {
+        box = sandbox();
+    });
+
+    afterEach(() => {
+        box.cleanup();
+    });
+
+    it("returns every byte of a PDF larger than the 1024-byte header window, unshifted and untruncated", async () => {
+        // The implementation reads a 1024-byte header at an explicit position
+        // so the handle's own offset stays at 0 and the following readFile()
+        // still yields the whole file. Drop the explicit position and this
+        // upload silently loses its first 1024 bytes. The filler is a
+        // non-repeating byte pattern so any shift or truncation shows up as a
+        // mismatch rather than coincidentally comparing equal.
+        const filler = Buffer.from(
+            Array.from({ length: 4096 }, (_, i) => (i * 7 + 13) % 251),
+        );
+        const pdf = Buffer.concat([
+            FIXTURES.pdf,
+            filler,
+            Buffer.from("\n%%EOF\n"),
+        ]);
+        assert.ok(
+            pdf.length > 1024 * 4,
+            "fixture must be several header windows long",
+        );
+
+        const path = box.file("outside/statement.pdf", pdf);
+
+        const result = await withAttachmentsDir(undefined, () =>
+            readAttachment(path),
+        );
+
+        assert.equal(
+            result.ok,
+            true,
+            `expected success, got: ${result.message}`,
+        );
+        assert.equal(result.mime, "application/pdf");
+        assert.equal(
+            result.data.length,
+            pdf.length,
+            "returned buffer length must match the file on disk",
+        );
+        assert.ok(
+            result.data.equals(pdf),
+            "returned bytes must equal the file's contents exactly",
+        );
+        assert.ok(
+            result.data.equals(readFileSync(path)),
+            "returned bytes must equal a plain readFile of the same path",
+        );
+    });
+});

--- a/test/attachments.sniff.test.mjs
+++ b/test/attachments.sniff.test.mjs
@@ -1,0 +1,262 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { sniffMimeType, contentTypeMatches } from "../build/attachments.js";
+import { FIXTURES, isoBmff } from "./helpers.mjs";
+
+/**
+ * Content sniffing is the control that closed the arbitrary-file-read reported
+ * in issue #16: the caller's `content_type` is an assertion, the file's leading
+ * bytes are the authority. Every test below names the property it protects so a
+ * failure reads as "this security guarantee broke", not "a string changed".
+ */
+
+describe("sniffMimeType — accepted types are recognised from real bytes", () => {
+    it("recognises a real PNG by its 8-byte signature", () => {
+        assert.equal(sniffMimeType(FIXTURES.png), "image/png");
+    });
+
+    it("recognises a real JPEG by its SOI marker", () => {
+        assert.equal(sniffMimeType(FIXTURES.jpeg), "image/jpeg");
+    });
+
+    it("recognises a PDF whose header is at offset 0", () => {
+        assert.equal(sniffMimeType(FIXTURES.pdf), "application/pdf");
+    });
+
+    it("recognises a PDF behind a scanner preamble (header is not anchored at byte 0)", () => {
+        assert.equal(
+            sniffMimeType(FIXTURES.pdfWithPreamble),
+            "application/pdf",
+        );
+    });
+
+    it("finds %PDF- late in the 1024-byte window, as conforming readers do", () => {
+        const padded = Buffer.concat([
+            Buffer.alloc(900, 0x20),
+            Buffer.from("%PDF-1.7\n%%EOF\n"),
+        ]);
+        assert.equal(sniffMimeType(padded), "application/pdf");
+    });
+});
+
+describe("sniffMimeType — ISO-BMFF brand handling", () => {
+    for (const brand of ["heic", "heix", "hevc", "hevx"]) {
+        it(`maps major brand ${brand} to image/heic`, () => {
+            assert.equal(sniffMimeType(isoBmff(brand)), "image/heic");
+        });
+    }
+
+    for (const brand of ["mif1", "msf1", "heim", "heis", "hevm", "hevs"]) {
+        it(`maps major brand ${brand} to image/heif`, () => {
+            assert.equal(sniffMimeType(isoBmff(brand)), "image/heif");
+        });
+    }
+
+    it("classifies an iOS .HEIC (major brand mif1, compatible heic) as image/heif", () => {
+        // The major brand wins; compatible brands are deliberately ignored.
+        // contentTypeMatches() is what stops this from rejecting a caller who
+        // sensibly calls the file image/heic.
+        assert.equal(sniffMimeType(isoBmff("mif1", ["heic"])), "image/heif");
+    });
+
+    it("ignores compatible brands when the major brand already decides", () => {
+        assert.equal(
+            sniffMimeType(isoBmff("heic", ["mif1", "miaf", "MiHB"])),
+            "image/heic",
+        );
+    });
+});
+
+describe("sniffMimeType — rejects everything outside the allow-list (issue #16)", () => {
+    it("returns null for an SSH private key, so key material can never be uploaded", () => {
+        assert.equal(sniffMimeType(FIXTURES.privateKey), null);
+    });
+
+    it("returns null for a dotenv file, so credentials can never be uploaded", () => {
+        assert.equal(sniffMimeType(FIXTURES.dotenv), null);
+    });
+
+    it("returns null for /etc/passwd contents, so host account data can never be uploaded", () => {
+        assert.equal(sniffMimeType(FIXTURES.passwd), null);
+    });
+
+    it("returns null for arbitrary text", () => {
+        assert.equal(sniffMimeType(Buffer.from("just some notes\n")), null);
+    });
+
+    it("returns null for an empty buffer", () => {
+        assert.equal(sniffMimeType(Buffer.alloc(0)), null);
+    });
+
+    it("returns null for an ISO-BMFF container whose brand is not HEIC/HEIF (avif)", () => {
+        assert.equal(sniffMimeType(isoBmff("avif")), null);
+    });
+
+    it("returns null for a QuickTime ISO-BMFF container", () => {
+        assert.equal(sniffMimeType(isoBmff("qt  ")), null);
+    });
+
+    it("returns null for an MP4 ISO-BMFF container", () => {
+        assert.equal(sniffMimeType(isoBmff("isom", ["mp41"])), null);
+    });
+
+    it("does not treat a file merely mentioning HEIC brand names as an image", () => {
+        assert.equal(sniffMimeType(Buffer.from("heic mif1 hevc\n")), null);
+    });
+});
+
+describe("sniffMimeType — truncated and partial signatures are not accepted", () => {
+    it("returns null for the first 2 bytes of a PNG signature", () => {
+        assert.equal(sniffMimeType(FIXTURES.png.subarray(0, 2)), null);
+    });
+
+    it("returns null for a 7-byte PNG signature (one byte short)", () => {
+        assert.equal(sniffMimeType(FIXTURES.png.subarray(0, 7)), null);
+    });
+
+    it("returns null for a partial PDF header (%PD)", () => {
+        assert.equal(sniffMimeType(Buffer.from("%PD")), null);
+    });
+
+    it("returns null for a 3-byte buffer that is not a JPEG SOI", () => {
+        assert.equal(sniffMimeType(Buffer.from([0xff, 0xd8, 0x00])), null);
+    });
+
+    it("returns null for a 2-byte JPEG SOI with the third marker byte missing", () => {
+        assert.equal(sniffMimeType(Buffer.from([0xff, 0xd8])), null);
+    });
+});
+
+describe("sniffMimeType — boundary and robustness", () => {
+    it("does not throw for every prefix length of every fixture", () => {
+        for (const [name, buffer] of Object.entries(FIXTURES)) {
+            for (let n = 0; n <= buffer.length; n++) {
+                assert.doesNotThrow(
+                    () => sniffMimeType(buffer.subarray(0, n)),
+                    `sniffMimeType threw on ${name} truncated to ${n} bytes`,
+                );
+            }
+        }
+    });
+
+    it("does not throw for every prefix length of an ISO-BMFF header", () => {
+        const heic = isoBmff("heic");
+        for (let n = 0; n <= heic.length; n++) {
+            assert.doesNotThrow(() => sniffMimeType(heic.subarray(0, n)));
+        }
+    });
+
+    it("accepts a buffer that is exactly the PNG signature length", () => {
+        assert.equal(sniffMimeType(FIXTURES.png.subarray(0, 8)), "image/png");
+    });
+
+    it("accepts a buffer that is exactly the JPEG signature length", () => {
+        assert.equal(
+            sniffMimeType(Buffer.from([0xff, 0xd8, 0xff])),
+            "image/jpeg",
+        );
+    });
+
+    it("accepts a buffer that is exactly the PDF marker length", () => {
+        assert.equal(sniffMimeType(Buffer.from("%PDF-")), "application/pdf");
+    });
+
+    it("accepts a buffer that is exactly the ISO-BMFF brand length (12 bytes)", () => {
+        const twelve = isoBmff("heic").subarray(0, 12);
+        assert.equal(twelve.length, 12);
+        assert.equal(sniffMimeType(twelve), "image/heic");
+    });
+
+    it("returns null, not a throw, when ftyp is present but the buffer ends before the brand", () => {
+        const truncated = isoBmff("heic").subarray(0, 8);
+        assert.equal(truncated.subarray(4, 8).toString("latin1"), "ftyp");
+        assert.equal(sniffMimeType(truncated), null);
+    });
+
+    it("returns null, not a throw, when the brand itself is cut short", () => {
+        const truncated = isoBmff("heic").subarray(0, 11);
+        assert.equal(sniffMimeType(truncated), null);
+    });
+});
+
+describe("contentTypeMatches — the caller's declared type is only ever a cross-check", () => {
+    it("matches identical types", () => {
+        for (const type of [
+            "image/png",
+            "image/jpeg",
+            "application/pdf",
+            "image/heic",
+            "image/heif",
+        ]) {
+            assert.equal(contentTypeMatches(type, type), true);
+        }
+    });
+
+    it("treats image/heic declared against image/heif bytes as a match", () => {
+        assert.equal(contentTypeMatches("image/heic", "image/heif"), true);
+    });
+
+    it("treats image/heif declared against image/heic bytes as a match (both directions)", () => {
+        assert.equal(contentTypeMatches("image/heif", "image/heic"), true);
+    });
+
+    it("does not match image/png against application/pdf", () => {
+        assert.equal(contentTypeMatches("image/png", "application/pdf"), false);
+        assert.equal(contentTypeMatches("application/pdf", "image/png"), false);
+    });
+
+    it("does not match image/jpeg against image/heic", () => {
+        assert.equal(contentTypeMatches("image/jpeg", "image/heic"), false);
+        assert.equal(contentTypeMatches("image/heic", "image/jpeg"), false);
+    });
+
+    it("does not let the HEIF family widen to unrelated types", () => {
+        assert.equal(contentTypeMatches("image/heic", "image/png"), false);
+        assert.equal(contentTypeMatches("text/plain", "text/plain"), true);
+        assert.equal(
+            contentTypeMatches("image/heif", "application/pdf"),
+            false,
+        );
+    });
+});
+
+describe("declaring an allowed content_type cannot launder a secret file", () => {
+    it("leaves a private key unclassified, so no declared type can ever match it", () => {
+        const actual = sniffMimeType(FIXTURES.privateKey);
+        assert.equal(
+            actual,
+            null,
+            "a private key must never sniff as an allowed attachment type",
+        );
+        // With no actual type there is nothing to compare against: the read is
+        // rejected before contentTypeMatches() is ever consulted. Prove that no
+        // allowed declaration would have matched even if it were.
+        for (const declared of [
+            "image/jpeg",
+            "image/png",
+            "image/heic",
+            "image/heif",
+            "application/pdf",
+        ]) {
+            assert.equal(
+                contentTypeMatches(declared, String(actual)),
+                false,
+                `declaring ${declared} must not make a private key uploadable`,
+            );
+        }
+    });
+
+    it("leaves dotenv and /etc/passwd contents unclassified for the same reason", () => {
+        for (const [name, buffer] of Object.entries({
+            dotenv: FIXTURES.dotenv,
+            passwd: FIXTURES.passwd,
+        })) {
+            assert.equal(
+                sniffMimeType(buffer),
+                null,
+                `${name} must never sniff as an allowed attachment type`,
+            );
+        }
+    });
+});

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -1,0 +1,146 @@
+import { execFileSync } from "node:child_process";
+import {
+    mkdtempSync,
+    rmSync,
+    writeFileSync,
+    mkdirSync,
+    symlinkSync,
+    realpathSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Minimal but genuine file contents for each type the attachments endpoint
+ * accepts, plus the kinds of files the sniffing check exists to keep out.
+ */
+export const FIXTURES = {
+    // Real 1x1 PNG.
+    png: Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+        "base64",
+    ),
+    // JPEG SOI + APP0/JFIF.
+    jpeg: Buffer.concat([
+        Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]),
+        Buffer.from("JFIF\0"),
+        Buffer.alloc(16),
+    ]),
+    pdf: Buffer.from("%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n%%EOF\n"),
+    // A PDF from a scanner that emits a preamble before the header.
+    pdfWithPreamble: Buffer.concat([
+        Buffer.from("\r\n#!scanner preamble, not part of the PDF\r\n"),
+        Buffer.from("%PDF-1.7\ntrailer\n%%EOF\n"),
+    ]),
+    privateKey: Buffer.from(
+        "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA\n-----END OPENSSH PRIVATE KEY-----\n",
+    ),
+    dotenv: Buffer.from(
+        "AWS_SECRET_ACCESS_KEY=AKIA-PLANTED-9999\nDB_PASS=hunter2\n",
+    ),
+    passwd: Buffer.from(
+        "root:x:0:0:root:/root:/bin/bash\ndaemon:x:1:1::/usr/sbin:/usr/sbin/nologin\n",
+    ),
+};
+
+/**
+ * Build an ISO-BMFF header with the given major brand, as HEIC/HEIF files use.
+ * `compatible` brands follow the major brand and are deliberately ignored by
+ * the sniffer — real `.HEIC` files often put `heic` there and `mif1` in front.
+ */
+export function isoBmff(majorBrand, compatible = []) {
+    const body = Buffer.concat([
+        Buffer.from("ftyp"),
+        Buffer.from(majorBrand, "latin1"),
+        Buffer.from([0, 0, 0, 0]), // minor version
+        ...compatible.map((b) => Buffer.from(b, "latin1")),
+    ]);
+    const size = Buffer.alloc(4);
+    size.writeUInt32BE(body.length + 4);
+    return Buffer.concat([size, body, Buffer.alloc(64)]);
+}
+
+/**
+ * A throwaway directory tree for one test.
+ *
+ * `root` holds a `vault/` (the directory a test points
+ * LUNCHMONEY_ATTACHMENTS_DIR at) and an `outside/` sibling to escape into.
+ * Paths are realpath'd up front so assertions are not confused by macOS
+ * symlinking /var to /private/var.
+ */
+export function sandbox() {
+    const real = realpathSync(mkdtempSync(join(tmpdir(), "lm-attach-")));
+    const vault = join(real, "vault");
+    const outside = join(real, "outside");
+    mkdirSync(vault);
+    mkdirSync(outside);
+
+    return {
+        root: real,
+        vault,
+        outside,
+        /** Write `contents` to `rel` (relative to the sandbox root); returns the path. */
+        file(rel, contents) {
+            const p = join(real, rel);
+            writeFileSync(p, contents);
+            return p;
+        },
+        /** Create a directory at `rel`; returns the path. */
+        dir(rel) {
+            const p = join(real, rel);
+            mkdirSync(p, { recursive: true });
+            return p;
+        },
+        /** Create a symlink at `rel` pointing to `target`; returns the link path. */
+        link(rel, target) {
+            const p = join(real, rel);
+            symlinkSync(target, p);
+            return p;
+        },
+        /** Create a FIFO at `rel`; returns the path. */
+        fifo(rel) {
+            const p = join(real, rel);
+            execFileSync("mkfifo", [p]);
+            return p;
+        },
+        /** Create a sparse file of `bytes` length without allocating it; returns the path. */
+        sparse(rel, bytes) {
+            const p = join(real, rel);
+            execFileSync(
+                "dd",
+                ["if=/dev/zero", `of=${p}`, "bs=1", "count=0", `seek=${bytes}`],
+                { stdio: "ignore" },
+            );
+            return p;
+        },
+        cleanup() {
+            rmSync(real, { recursive: true, force: true });
+        },
+    };
+}
+
+/**
+ * Run `fn` with LUNCHMONEY_ATTACHMENTS_DIR set to `value` (or unset when
+ * `value` is undefined), restoring the previous value afterwards.
+ */
+export async function withAttachmentsDir(value, fn) {
+    const key = "LUNCHMONEY_ATTACHMENTS_DIR";
+    const previous = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+    try {
+        return await fn();
+    } finally {
+        if (previous === undefined) delete process.env[key];
+        else process.env[key] = previous;
+    }
+}
+
+/** Swallow the stderr `console.error` calls the module makes on failure paths. */
+export function muteStderr() {
+    const original = console.error;
+    console.error = () => {};
+    return () => {
+        console.error = original;
+    };
+}

--- a/test/transactions.tool.test.mjs
+++ b/test/transactions.tool.test.mjs
@@ -1,0 +1,173 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { createServer } from "../build/server.js";
+import { initializeConfig } from "../build/config.js";
+import {
+    sandbox,
+    FIXTURES,
+    withAttachmentsDir,
+    muteStderr,
+} from "./helpers.mjs";
+
+/**
+ * Integration cover for the `attach_file_to_transaction` boundary itself,
+ * driven through a real MCP client over an in-memory transport.
+ *
+ * The unit tests in attachments.*.test.mjs prove the reader is safe. These
+ * prove the *tool* still wires that reader up correctly and still advertises a
+ * schema that can't be talked around — the original issue #16 report turned on
+ * `content_type` being a free-form string the caller controlled.
+ *
+ * Nothing here reaches the network: every case is rejected before the upload,
+ * which is exactly the property being asserted.
+ */
+describe("attach_file_to_transaction — tool boundary", () => {
+    let client;
+    let box;
+
+    before(async () => {
+        initializeConfig("TEST-TOKEN-NOT-USED");
+        const server = createServer("test");
+        const [clientTransport, serverTransport] =
+            InMemoryTransport.createLinkedPair();
+        client = new Client({ name: "test", version: "0" });
+        await Promise.all([
+            client.connect(clientTransport),
+            server.connect(serverTransport),
+        ]);
+    });
+
+    after(async () => {
+        await client.close();
+    });
+
+    before(() => {
+        box = sandbox();
+    });
+
+    after(() => {
+        box.cleanup();
+    });
+
+    const schema = async () => {
+        const { tools } = await client.listTools();
+        const tool = tools.find((t) => t.name === "attach_file_to_transaction");
+        assert.ok(tool, "attach_file_to_transaction should be registered");
+        return tool;
+    };
+
+    it("advertises content_type as a closed enum, not a free-form string", async () => {
+        // The issue #16 report leaned on content_type being any string the
+        // caller liked. Even though the file's bytes are now authoritative,
+        // the schema should not re-open that door.
+        const { inputSchema } = await schema();
+        const contentType = inputSchema.properties.content_type;
+        const values =
+            contentType.enum ?? contentType.anyOf?.flatMap((s) => s.enum ?? []);
+        assert.deepEqual(
+            [...values].sort(),
+            [
+                "application/pdf",
+                "image/heic",
+                "image/heif",
+                "image/jpeg",
+                "image/png",
+            ],
+            "content_type must be restricted to the allowed attachment types",
+        );
+    });
+
+    it("tells the model the type is verified from file contents", async () => {
+        const tool = await schema();
+        assert.match(tool.description, /contents/i);
+        assert.match(tool.description, /LUNCHMONEY_ATTACHMENTS_DIR/);
+    });
+
+    it("refuses a secret file even when the caller declares an allowed type", async () => {
+        const restore = muteStderr();
+        try {
+            const key = box.file("outside/id_rsa", FIXTURES.privateKey);
+            const result = await client.callTool({
+                name: "attach_file_to_transaction",
+                arguments: {
+                    transaction_id: 1,
+                    file_path: key,
+                    content_type: "image/png",
+                },
+            });
+            assert.equal(result.isError, true);
+            assert.match(
+                result.content[0].text,
+                /not a supported attachment type/,
+            );
+        } finally {
+            restore();
+        }
+    });
+
+    it("refuses a path outside the configured attachments directory", async () => {
+        const restore = muteStderr();
+        try {
+            const outside = box.file("outside/receipt.png", FIXTURES.png);
+            const result = await withAttachmentsDir(box.vault, () =>
+                client.callTool({
+                    name: "attach_file_to_transaction",
+                    arguments: { transaction_id: 1, file_path: outside },
+                }),
+            );
+            assert.equal(result.isError, true);
+            assert.match(
+                result.content[0].text,
+                /resolves outside the directory configured in LUNCHMONEY_ATTACHMENTS_DIR/,
+            );
+        } finally {
+            restore();
+        }
+    });
+
+    it("refuses a genuine PNG that the caller mislabels as a PDF", async () => {
+        const restore = muteStderr();
+        try {
+            const png = box.file("vault/receipt.png", FIXTURES.png);
+            const result = await client.callTool({
+                name: "attach_file_to_transaction",
+                arguments: {
+                    transaction_id: 1,
+                    file_path: png,
+                    content_type: "application/pdf",
+                },
+            });
+            assert.equal(result.isError, true);
+            assert.match(result.content[0].text, /does not match/);
+        } finally {
+            restore();
+        }
+    });
+
+    it("rejects a content_type outside the enum at the schema layer", async () => {
+        const restore = muteStderr();
+        try {
+            const png = box.file("vault/schema.png", FIXTURES.png);
+            const result = await client
+                .callTool({
+                    name: "attach_file_to_transaction",
+                    arguments: {
+                        transaction_id: 1,
+                        file_path: png,
+                        content_type: "application/x-sh",
+                    },
+                })
+                .catch((error) => ({ isError: true, thrown: error }));
+            assert.ok(
+                result.isError,
+                "an unlisted content_type must not be accepted",
+            );
+        } finally {
+            restore();
+        }
+    });
+});


### PR DESCRIPTION
Fixes #16.

## The report

Accurate. Verified at HEAD — nothing in this path had changed since the commit the reporter cited (`fa3016d`). `attach_file_to_transaction` passed the caller-supplied `file_path` straight to `readFile` with no confinement, and its MIME allow-list checked a `content_type` the caller also supplied. `attach_file_to_transaction` is the only tool in the server that touches the filesystem.

I reproduced it over raw JSON-RPC against the stdio server with a fake token. Every case was read off disk and uploaded, failing only at the 401:

```
### BASELINE (pre-fix) ###
  absolute path to a private key   -> (401) Unauthorized   <- file was read and sent
  secret renamed with .png ext     -> (401) Unauthorized
  symlink inside vault -> id_rsa   -> (401) Unauthorized
  ../ traversal out of vault       -> (401) Unauthorized
  /etc/passwd                      -> (401) Unauthorized
```

Two notes on the framing. The MIME gate wasn't "bypassed" — a caller can't declare an arbitrary type, it's still membership-checked; what they could do is attach arbitrary *bytes* under an allowed *label*. And per the comment at the call site, that check was written as data hygiene (avoid `type=unknown` orphans), never as a security boundary. The real gap was the absent confinement.

Two things the report missed, both fixed here: the 10MB cap was applied *after* `readFile` buffered the whole file, and `catchError` echoed raw errno text back to the caller.

## Why content sniffing rather than the suggested fix

The report proposes a mandatory `LUNCHMONEY_ATTACHMENTS_DIR` that fails closed when unset. That breaks the tool out of the box for every desktop user attaching a receipt from `~/Downloads`. The softer version — confine to `$HOME` + cwd, as the cited `luma-mcp` precedent does — is close to theater, since `~/.ssh/id_rsa` and `~/.aws/credentials` are the juiciest targets and both live under `$HOME`.

Requiring the bytes to actually **be** a JPEG/PNG/HEIC/HEIF/PDF rules those out wherever they live, at zero UX cost. An attacker can't make `/etc/shadow` start with `%PDF-`. That's the load-bearing control; path confinement is the opt-in boundary for deployments that need one.

## Changes

1. **Content sniffing.** MIME comes from the leading bytes (JPEG `FF D8 FF`, PNG signature, `%PDF-`, ISO-BMFF `ftyp` + brand for HEIC/HEIF). The header is read at an explicit position *before* the rest of the file, so rejected files are never buffered.
2. **Optional `LUNCHMONEY_ATTACHMENTS_DIR`**, enforced after `realpath` so `..` and symlink escapes are both caught. Unset = unconfined, preserving current desktop behaviour. Documented as required for the HTTP deployments in the README, where caller and file owner are no longer the same principal — that's where this is genuinely High rather than a confused-deputy nuisance.
3. **`stat` before read**, plus `isFile()`. `readFile("/dev/zero")` previously grew unbounded — I measured ~11GB RSS in 10 seconds before giving up.
4. **Generic error text** to the caller, detail to stderr, so failed reads no longer distinguish `ENOENT` from `EACCES`.

`content_type` becomes an optional `z.enum` treated as an assertion: the file's real type wins, and a mismatch is rejected rather than silently corrected.

## Verification

Same probe, post-fix:

```
===== LUNCHMONEY_ATTACHMENTS_DIR unset =====
  absolute path to a private key  -> contents are not a supported attachment type
  secret renamed with .png ext    -> contents are not a supported attachment type
  symlink inside vault -> id_rsa  -> contents are not a supported attachment type
  ../ traversal out of vault      -> contents are not a supported attachment type
  /etc/passwd                     -> contents are not a supported attachment type
  character device /dev/zero      -> file_path must point to a regular file
  genuine PNG inside vault        -> (401) Unauthorized   <- passes validation, uploads
  genuine PDF inside vault        -> (401) Unauthorized   <- passes validation, uploads
  genuine PNG, declared as PDF    -> declared content_type does not match actual type

===== LUNCHMONEY_ATTACHMENTS_DIR=<vault> =====
  everything outside the vault    -> resolves outside LUNCHMONEY_ATTACHMENTS_DIR
  genuine PNG / PDF inside vault  -> (401) Unauthorized   <- still works
```

The 401s are the fake token; reaching them means validation passed and the upload was attempted. Repo has no test suite, so this was driven through the built stdio binary over JSON-RPC.

`npm run build` and `npm run format` both clean. README, CHANGELOG, and `manifest.json` (tool description + new `user_config` entry) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)