### PR TITLE
feat(crypto)!: migrate crypto tools from v1 to v2 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.0] - 2026-08-03
+
+**Breaking change**, scoped to the crypto tools. Crypto was the last domain still calling LunchMoney's v1 API; this release moves it to v2, so the server no longer talks to `dev.lunchmoney.app/v1` at all. `get_all_crypto` — present in every release since 1.0.0 — is removed, because v2 has no combined crypto endpoint to back it. Every other domain is untouched. Tool count grows from 50 to 59.
+
+### Breaking
+
+- **`get_all_crypto` is removed.** v2 splits crypto into separate manual and synced resources with different shapes, and offers nothing equivalent to v1's combined `GET /crypto`. Use `get_all_manual_crypto` and `get_all_synced_crypto` instead — together they cover everything the old tool returned, with more detail. The bundled `net_worth_snapshot` prompt now calls both.
+- **`update_manual_crypto` changed shape.** It targets `PUT /crypto/manual/{id}` on v2. All writable fields are now optional, but at least one of `name`, `display_name`, `institution_name`, or `balance` must be supplied. The `currency` parameter is gone: a manual balance's symbol is fixed when the asset is created, and v2 ignores attempts to change it.
+
+### Added
+
+- **Ten new crypto tools** covering v2's [crypto-manual](https://lunchmoney.dev/v2/docs#tag/crypto-manual) and [crypto-synced](https://lunchmoney.dev/v2/docs#tag/crypto-synced) endpoints: `get_supported_cryptocurrencies`, `add_supported_cryptocurrency`, `get_all_manual_crypto`, `get_single_manual_crypto`, `create_manual_crypto`, `delete_manual_crypto`, `get_all_synced_crypto`, `get_single_synced_crypto`, `get_synced_crypto_balance`, `refresh_synced_crypto`.
+    - Manual crypto balances now support full CRUD, where v1 only allowed updates — assets can be created and deleted through the API for the first time.
+    - Synced crypto accounts (Kraken, Coinbase, Ethereum) are readable as first-class accounts with their nested per-symbol balances, individually addressable by symbol. Connections themselves are still created only in the LunchMoney web app.
+    - `add_supported_cryptocurrency` extends the manual-crypto currency list from a CoinGecko coin-page URL, so tracking a coin LunchMoney doesn't know yet no longer requires the web app.
+    - `refresh_synced_crypto` triggers a provider-side balance refresh and returns the refreshed account.
+
+### Changed
+
+- Crypto balances are now forwarded to the API exactly as supplied, instead of being coerced to a JS number and re-stringified. v2 carries balances to 18 decimal places, which exceeds a double's precision, so a string like `0.852341920145782301` no longer silently rounds on write. Numbers are still accepted — v2 takes either — and are passed through unconverted, since stringifying them would turn a satoshi (`1e-8`) into exponential notation that the decimal format rejects.
+- Removed the `apiV1` export and the `baseUrlOverride` parameter it relied on. Nothing else used them.
+- `CryptoAsset` replaced by `Cryptocurrency`, `ManualCrypto`, `SyncedCryptoBalance`, and `SyncedCryptoAccount`, matching the v2 response shapes.
+- Error hint fields extended so the model can recover from the new crypto failure modes without a round-trip (`crypto_manual_id`, `has_balance_history`, `required_parameter`, `allowed_values`, `coingecko_url`, `existing_coingecko_id`, `existing_symbol`). The `DELETE /crypto/manual/{id}` 422 that demands an explicit `keep_history` is the main beneficiary.
+
 ## [2.2.0] - 2026-08-01
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MCP (Model Context Protocol) server for the LunchMoney personal finance API (v2). Provides 50 tools across 10 domains (transactions, categories, budgets, manual accounts, tags, recurring items, user, Plaid accounts, crypto, balance history). Uses stdio transport and is published to npm as `@akutishevsky/lunchmoney-mcp`.
+MCP (Model Context Protocol) server for the LunchMoney personal finance API (v2). Provides 59 tools across 10 domains (transactions, categories, budgets, manual accounts, tags, recurring items, user, Plaid accounts, crypto, balance history). Uses stdio transport and is published to npm as `@akutishevsky/lunchmoney-mcp`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 A Model Context Protocol (MCP) server implementation for [LunchMoney](https://lunchmoney.app/), providing programmatic access to personal finance management through LunchMoney's API. Also available as an MCP Bundle (.mcpb) for easy installation in Claude Desktop.
 
+> **Heads up — v3.0.0 removes `get_all_crypto`.** The crypto tools now use LunchMoney's v2 crypto endpoints, which split manual and synced holdings into separate resources and offer no combined equivalent of v1's `GET /crypto`. Replace `get_all_crypto` with `get_all_manual_crypto` and `get_all_synced_crypto`, which together return everything it did and more. `update_manual_crypto` also drops its `currency` parameter. Nothing outside the crypto domain changed; if you don't use the crypto tools, upgrading from 2.x needs no action. See [CHANGELOG.md](./CHANGELOG.md). If you depend on `get_all_crypto`, pin `@akutishevsky/lunchmoney-mcp@^2.2.0`.
+
 > **Heads up — v2.0.0 is a breaking release.** This server now targets LunchMoney's v2 API (`https://api.lunchmoney.dev/v2`, currently in alpha). It is not backwards-compatible with v1.x of this server: tool names, fields, and endpoint shapes have changed (for example, `assets` is now `manual_accounts`, `tags` arrays are now `tag_ids`, transaction `asset_id` is now `manual_account_id`, the `debit_as_negative` toggle is gone, and the budget summary moved to a new `/summary` endpoint). See [CHANGELOG.md](./CHANGELOG.md) for the full list. If you depend on v1.x, pin `@akutishevsky/lunchmoney-mcp@^1.4.3`.
 
 <a href="https://glama.ai/mcp/servers/@akutishevsky/lunchmoney-mcp">
@@ -50,7 +52,7 @@ This MCP server enables AI assistants and other MCP clients to interact with Lun
 - **Budgets** - Per-period budget summary, account-wide budget settings, upsert, and delete
 - **Manual Accounts** - Full CRUD for manually-managed accounts (formerly known as "assets")
 - **Plaid Accounts** - List, retrieve, and trigger sync of connected bank accounts
-- **Cryptocurrency** - Track synced and manual crypto holdings through LunchMoney's v1 crypto endpoints
+- **Cryptocurrency** - Full CRUD for manual crypto balances, read and refresh synced crypto accounts, and manage the supported-cryptocurrency list
 - **Balance History** - Read, upsert, and delete monthly balance history for manual, Plaid, crypto, and deleted accounts
 
 ### Key Capabilities
@@ -289,6 +291,9 @@ Here are some example prompts you can use with the LunchMoney MCP server:
 - "Show me all my crypto holdings"
 - "Update my Bitcoin balance to 0.5 BTC"
 - "List all my manually tracked crypto assets"
+- "Add a cold wallet holding 0.85 BTC called Ledger Cold Storage"
+- "Refresh my Coinbase account and show the updated balances"
+- "Which cryptocurrencies can I track manually?"
 
 ### Net Worth & Balance History
 
@@ -371,8 +376,17 @@ Here are some example prompts you can use with the LunchMoney MCP server:
 
 ### Crypto Tools
 
-- `get_all_crypto` - List synced and manual cryptocurrency holdings from `/v1/crypto`
-- `update_manual_crypto` - Update a manually-managed cryptocurrency asset via `/v1/crypto/manual/:id`
+- `get_supported_cryptocurrencies` - List the cryptocurrencies supported for manual tracking
+- `add_supported_cryptocurrency` - Add a cryptocurrency to the supported list from its CoinGecko coin-page URL
+- `get_all_manual_crypto` - List all manually-managed crypto balances
+- `get_single_manual_crypto` - Get a single manually-managed crypto balance by ID
+- `create_manual_crypto` - Create a manually-managed crypto asset
+- `update_manual_crypto` - Update a manual crypto balance's name, display name, institution name, or balance
+- `delete_manual_crypto` - Delete a manual crypto asset (irreversible)
+- `get_all_synced_crypto` - List synced crypto accounts and their nested per-symbol balances
+- `get_single_synced_crypto` - Get a single synced crypto account by ID
+- `get_synced_crypto_balance` - Get one balance inside a synced crypto account by symbol
+- `refresh_synced_crypto` - Trigger a balance refresh for a synced crypto account
 
 ### Balance History Tools
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": "0.3",
     "name": "lunchmoney",
     "display_name": "Lunch Money",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "Manage your Lunch Money finances with AI assistance",
     "long_description": "Connect Claude to your Lunch Money account to analyze spending patterns, manage budgets, track transactions, and get insights about your finances. This extension provides full access to Lunch Money's v2 API, enabling you to manage categories, transactions, budgets, manual accounts, tags, recurring items, balance history, and more through natural language commands.",
     "author": {
@@ -182,12 +182,48 @@
             "description": "Delete a transaction file attachment. Irreversible."
         },
         {
-            "name": "get_all_crypto",
-            "description": "Get cryptocurrency holdings from the v1 crypto endpoint, including synced and manual crypto assets."
+            "name": "get_supported_cryptocurrencies",
+            "description": "Get the list of cryptocurrencies supported for manual tracking. Provides the symbols accepted by create_manual_crypto."
+        },
+        {
+            "name": "add_supported_cryptocurrency",
+            "description": "Add a new cryptocurrency to the supported manual-crypto list by submitting its CoinGecko coin-page URL."
+        },
+        {
+            "name": "get_all_manual_crypto",
+            "description": "Get all manually-managed crypto balances associated with the user."
+        },
+        {
+            "name": "get_single_manual_crypto",
+            "description": "Get a single manually-managed crypto balance by ID."
+        },
+        {
+            "name": "create_manual_crypto",
+            "description": "Create a manually-managed crypto asset with a name, balance, and supported cryptocurrency symbol."
         },
         {
             "name": "update_manual_crypto",
-            "description": "Update a manually-managed crypto asset via the v1 crypto endpoint."
+            "description": "Update a manually-managed crypto balance's name, display name, institution name, or balance."
+        },
+        {
+            "name": "delete_manual_crypto",
+            "description": "Delete a manually-managed crypto asset. Requires keep_history to be set explicitly when the asset has balance history. Irreversible."
+        },
+        {
+            "name": "get_all_synced_crypto",
+            "description": "Get all synced crypto accounts and their nested per-symbol balances."
+        },
+        {
+            "name": "get_single_synced_crypto",
+            "description": "Get a single synced crypto account and all its nested balances by ID."
+        },
+        {
+            "name": "get_synced_crypto_balance",
+            "description": "Get a single balance held inside a synced crypto account, looked up by its cryptocurrency symbol."
+        },
+        {
+            "name": "refresh_synced_crypto",
+            "description": "Trigger a balance refresh for a synced crypto account and return the refreshed account."
         },
         {
             "name": "get_balance_history",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@akutishevsky/lunchmoney-mcp",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "mcpName": "io.github.akutishevsky/lunchmoney-mcp",
     "description": "Model Context Protocol server for LunchMoney personal finance management",
     "main": "build/index.js",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
     "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
     "name": "io.github.akutishevsky/lunchmoney-mcp",
     "title": "Lunch Money",
-    "version": "2.2.0",
+    "version": "3.0.0",
     "description": "MCP server for managing LunchMoney personal finances: transactions, budgets, categories, and more.",
     "websiteUrl": "https://github.com/akutishevsky/lunchmoney-mcp#readme",
     "repository": {
@@ -14,7 +14,7 @@
         {
             "registryType": "npm",
             "identifier": "@akutishevsky/lunchmoney-mcp",
-            "version": "2.2.0",
+            "version": "3.0.0",
             "runtimeHint": "npx",
             "transport": {
                 "type": "stdio"

--- a/src/api.ts
+++ b/src/api.ts
@@ -24,7 +24,6 @@ async function apiRequest(
     method: string,
     path: string,
     body?: unknown,
-    baseUrlOverride?: string,
 ): Promise<Response> {
     const { baseUrl, lunchmoneyApiToken } = getConfig();
 
@@ -44,7 +43,7 @@ async function apiRequest(
         options.body = JSON.stringify(body);
     }
 
-    const url = `${baseUrlOverride ?? baseUrl}${path}`;
+    const url = `${baseUrl}${path}`;
 
     if (isDebug()) {
         const parts = [`[API Request] ${method} ${path}`];
@@ -150,13 +149,6 @@ export const api = {
     delete: (path: string, body?: unknown) => apiRequest("DELETE", path, body),
     upload: (path: string, formData: FormData) =>
         apiUpload("POST", path, formData),
-};
-
-export const apiV1 = {
-    get: (path: string) =>
-        apiRequest("GET", path, undefined, "https://dev.lunchmoney.app/v1"),
-    put: (path: string, body: unknown) =>
-        apiRequest("PUT", path, body, "https://dev.lunchmoney.app/v1"),
 };
 
 export function successResponse(text: string) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -15,6 +15,13 @@ const V2_ERROR_HINT_FIELDS = [
     "external_id",
     "invalid_property",
     "locked_property",
+    "crypto_manual_id",
+    "has_balance_history",
+    "required_parameter",
+    "allowed_values",
+    "coingecko_url",
+    "existing_coingecko_id",
+    "existing_symbol",
     "id",
 ] as const;
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -129,7 +129,7 @@ export function registerPrompts(server: McpServer) {
                                 "Steps:",
                                 "1. Call get_all_manual_accounts to fetch manually-managed accounts (formerly known as assets).",
                                 "2. Call get_all_plaid_accounts to fetch linked bank accounts.",
-                                "3. Call get_all_crypto to fetch cryptocurrency holdings from the v1 crypto endpoint.",
+                                "3. Call get_all_manual_crypto and get_all_synced_crypto to fetch cryptocurrency holdings.",
                                 "4. Group accounts by type (cash, investment, property, crypto, debt, etc.).",
                                 "5. Present a table with columns: Account Name, Type, Balance.",
                                 "6. Show subtotals for each type.",

--- a/src/tools/balance-history.ts
+++ b/src/tools/balance-history.ts
@@ -137,7 +137,7 @@ export function registerBalanceHistoryTools(server: McpServer) {
         "get_account_balance_history",
         {
             description:
-                "Get monthly balance history for a single account. Call get_all_manual_accounts, get_all_plaid_accounts, or get_all_crypto first to discover ids. For synced crypto holdings use get_crypto_synced_balance_history instead.",
+                "Get monthly balance history for a single account. Call get_all_manual_accounts, get_all_plaid_accounts, or get_all_manual_crypto first to discover ids. For synced crypto holdings use get_crypto_synced_balance_history instead.",
             inputSchema: {
                 account_type: accountTypeSchema,
                 account_id: z.coerce

--- a/src/tools/crypto.ts
+++ b/src/tools/crypto.ts
@@ -1,33 +1,249 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { apiV1, dataResponse, handleApiError, catchError } from "../api.js";
-import { CryptoAsset } from "../types.js";
+import {
+    api,
+    dataResponse,
+    handleApiError,
+    catchError,
+    errorResponse,
+    successResponse,
+} from "../api.js";
+import {
+    Cryptocurrency,
+    ManualCrypto,
+    SyncedCryptoAccount,
+    SyncedCryptoBalance,
+} from "../types.js";
+
+// v2 accepts a balance as either a number or a string of up to 18 decimal
+// places. A string holds more precision than a JS double, so it is the
+// preferred form and is forwarded untouched. Numbers are forwarded untouched
+// too rather than being stringified: String(1e-8) is "1e-8", which would fail
+// the decimal pattern even though one satoshi is a perfectly ordinary balance.
+const cryptoBalance = z.union([
+    z
+        .string()
+        .regex(
+            /^-?\d+(\.\d{1,18})?$/,
+            "Balance must be numeric with at most 18 decimal places.",
+        ),
+    z.number(),
+]);
 
 export function registerCryptoTools(server: McpServer) {
     server.registerTool(
-        "get_all_crypto",
+        "get_supported_cryptocurrencies",
         {
             description:
-                "Get all cryptocurrency holdings from the v1 crypto endpoint. Returns both synced and manually managed crypto assets.",
+                "Get the list of cryptocurrencies supported for manual tracking. The `symbol` of an entry here is what must be passed to create_manual_crypto.",
             annotations: {
                 readOnlyHint: true,
             },
         },
         async () => {
             try {
-                const response = await apiV1.get("/crypto");
+                const response = await api.get("/cryptocurrencies");
 
                 if (!response.ok) {
                     return handleApiError(
                         response,
-                        "Failed to get crypto assets",
+                        "Failed to get supported cryptocurrencies",
                     );
                 }
 
-                const data: { crypto: CryptoAsset[] } = await response.json();
+                const data: { cryptocurrencies: Cryptocurrency[] } =
+                    await response.json();
                 return dataResponse(data);
             } catch (error) {
-                return catchError(error, "Failed to get crypto assets");
+                return catchError(
+                    error,
+                    "Failed to get supported cryptocurrencies",
+                );
+            }
+        },
+    );
+
+    server.registerTool(
+        "add_supported_cryptocurrency",
+        {
+            description:
+                "Add a new cryptocurrency to the supported manual-crypto list by submitting its CoinGecko coin-page URL. Only needed when get_supported_cryptocurrencies does not already list the symbol you want to track.",
+            inputSchema: {
+                coingecko_url: z
+                    .string()
+                    .min(1)
+                    .max(200)
+                    .describe(
+                        "CoinGecko coin-page URL in the form https://www.coingecko.com/{locale}/coins/{id}, e.g. https://www.coingecko.com/en/coins/cardano.",
+                    ),
+            },
+            annotations: {
+                idempotentHint: false,
+            },
+        },
+        async ({ coingecko_url }) => {
+            try {
+                const response = await api.post("/cryptocurrencies", {
+                    coingecko_url,
+                });
+
+                if (!response.ok) {
+                    return handleApiError(
+                        response,
+                        "Failed to add supported cryptocurrency",
+                    );
+                }
+
+                const data: Cryptocurrency = await response.json();
+                return dataResponse(data);
+            } catch (error) {
+                return catchError(
+                    error,
+                    "Failed to add supported cryptocurrency",
+                );
+            }
+        },
+    );
+
+    server.registerTool(
+        "get_all_manual_crypto",
+        {
+            description:
+                "Get all manually-managed crypto balances associated with the user.",
+            annotations: {
+                readOnlyHint: true,
+            },
+        },
+        async () => {
+            try {
+                const response = await api.get("/crypto/manual");
+
+                if (!response.ok) {
+                    return handleApiError(
+                        response,
+                        "Failed to get manual crypto balances",
+                    );
+                }
+
+                const data: { crypto_manual: ManualCrypto[] } =
+                    await response.json();
+                return dataResponse(data);
+            } catch (error) {
+                return catchError(
+                    error,
+                    "Failed to get manual crypto balances",
+                );
+            }
+        },
+    );
+
+    server.registerTool(
+        "get_single_manual_crypto",
+        {
+            description:
+                "Get a single manually-managed crypto balance by ID. Call get_all_manual_crypto first to discover ids.",
+            inputSchema: {
+                crypto_id: z.coerce
+                    .number()
+                    .int()
+                    .describe("Id of the manual crypto balance to retrieve."),
+            },
+            annotations: {
+                readOnlyHint: true,
+            },
+        },
+        async ({ crypto_id }) => {
+            try {
+                const response = await api.get(`/crypto/manual/${crypto_id}`);
+
+                if (!response.ok) {
+                    return handleApiError(
+                        response,
+                        "Failed to get manual crypto balance",
+                    );
+                }
+
+                const data: ManualCrypto = await response.json();
+                return dataResponse(data);
+            } catch (error) {
+                return catchError(error, "Failed to get manual crypto balance");
+            }
+        },
+    );
+
+    server.registerTool(
+        "create_manual_crypto",
+        {
+            description:
+                "Create a manually-managed crypto asset. The symbol must match one returned by get_supported_cryptocurrencies.",
+            inputSchema: {
+                name: z
+                    .string()
+                    .min(1)
+                    .max(45)
+                    .describe(
+                        "User-defined name for the manual crypto asset, e.g. 'Cold Wallet BTC'.",
+                    ),
+                balance: cryptoBalance.describe(
+                    "Balance as a numeric string with up to 18 decimal places, e.g. '0.852341920145782301'. Pass a string to avoid losing precision.",
+                ),
+                symbol: z
+                    .string()
+                    .min(1)
+                    .max(25)
+                    .describe(
+                        "Cryptocurrency symbol to track, e.g. 'btc'. Must match a symbol from get_supported_cryptocurrencies.",
+                    ),
+                display_name: z
+                    .string()
+                    .min(1)
+                    .max(45)
+                    .optional()
+                    .describe(
+                        "Optional display name. If omitted, clients may derive one from institution_name and name.",
+                    ),
+                institution_name: z
+                    .string()
+                    .min(1)
+                    .max(50)
+                    .optional()
+                    .describe(
+                        "Optional institution or wallet provider display name, e.g. 'Ledger'.",
+                    ),
+            },
+            annotations: {
+                idempotentHint: false,
+            },
+        },
+        async ({ name, balance, symbol, display_name, institution_name }) => {
+            try {
+                const body: Record<string, unknown> = {
+                    name,
+                    balance,
+                    symbol,
+                };
+
+                if (display_name !== undefined)
+                    body.display_name = display_name;
+                if (institution_name !== undefined)
+                    body.institution_name = institution_name;
+
+                const response = await api.post("/crypto/manual", body);
+
+                if (!response.ok) {
+                    return handleApiError(
+                        response,
+                        "Failed to create manual crypto balance",
+                    );
+                }
+
+                const data: ManualCrypto = await response.json();
+                return dataResponse(data);
+            } catch (error) {
+                return catchError(
+                    error,
+                    "Failed to create manual crypto balance",
+                );
             }
         },
     );
@@ -36,35 +252,43 @@ export function registerCryptoTools(server: McpServer) {
         "update_manual_crypto",
         {
             description:
-                "Update a manually-managed crypto asset via the v1 crypto endpoint. The id must be from a get_all_crypto result with source=manual.",
+                "Update a manually-managed crypto balance. At least one of name, display_name, institution_name, or balance must be supplied. The symbol of an existing balance cannot be changed.",
             inputSchema: {
                 crypto_id: z.coerce
                     .number()
+                    .int()
                     .describe(
-                        "ID of the manual crypto asset to update. Synced crypto assets cannot be updated.",
+                        "Id of the manual crypto balance to update. Synced crypto balances cannot be updated.",
                     ),
-                balance: z.coerce
-                    .number()
-                    .describe("Updated balance of the crypto account."),
+                balance: cryptoBalance
+                    .optional()
+                    .describe(
+                        "New balance as a numeric string with up to 18 decimal places. Pass a string to avoid losing precision.",
+                    ),
                 name: z
                     .string()
+                    .min(1)
                     .max(45)
                     .optional()
-                    .describe("Optional official or full name of the account."),
+                    .describe("New name for the crypto asset."),
                 display_name: z
                     .string()
-                    .max(25)
+                    .min(1)
+                    .max(45)
+                    .nullable()
                     .optional()
-                    .describe("Optional display name for the account."),
+                    .describe(
+                        "New display name for the crypto asset. Pass null to clear it.",
+                    ),
                 institution_name: z
                     .string()
+                    .min(1)
                     .max(50)
+                    .nullable()
                     .optional()
-                    .describe("Optional provider that holds the asset."),
-                currency: z
-                    .string()
-                    .optional()
-                    .describe("Optional supported cryptocurrency code."),
+                    .describe(
+                        "New institution or wallet provider display name. Pass null to clear it.",
+                    ),
             },
             annotations: {
                 idempotentHint: true,
@@ -76,21 +300,24 @@ export function registerCryptoTools(server: McpServer) {
             name,
             display_name,
             institution_name,
-            currency,
         }) => {
             try {
-                const body: Record<string, unknown> = {
-                    balance: balance.toString(),
-                };
+                const body: Record<string, unknown> = {};
 
+                if (balance !== undefined) body.balance = balance;
                 if (name !== undefined) body.name = name;
                 if (display_name !== undefined)
                     body.display_name = display_name;
                 if (institution_name !== undefined)
                     body.institution_name = institution_name;
-                if (currency !== undefined) body.currency = currency;
 
-                const response = await apiV1.put(
+                if (Object.keys(body).length === 0) {
+                    return errorResponse(
+                        "Failed to update manual crypto balance: at least one property must be provided: name, display_name, institution_name, or balance.",
+                    );
+                }
+
+                const response = await api.put(
                     `/crypto/manual/${crypto_id}`,
                     body,
                 );
@@ -98,13 +325,218 @@ export function registerCryptoTools(server: McpServer) {
                 if (!response.ok) {
                     return handleApiError(
                         response,
-                        "Failed to update crypto asset",
+                        "Failed to update manual crypto balance",
+                    );
+                }
+
+                const data: ManualCrypto = await response.json();
+                return dataResponse(data);
+            } catch (error) {
+                return catchError(
+                    error,
+                    "Failed to update manual crypto balance",
+                );
+            }
+        },
+    );
+
+    server.registerTool(
+        "delete_manual_crypto",
+        {
+            description:
+                "Delete a manually-managed crypto asset. If the asset has balance history, keep_history must be set explicitly or the API rejects the request. Irreversible.",
+            inputSchema: {
+                crypto_id: z.coerce
+                    .number()
+                    .int()
+                    .describe("Id of the manual crypto balance to delete."),
+                keep_history: z
+                    .boolean()
+                    .optional()
+                    .describe(
+                        "Set true to preserve the balance history, false to delete it too. Required if the asset has balance history.",
+                    ),
+            },
+            annotations: {
+                destructiveHint: true,
+            },
+        },
+        async ({ crypto_id, keep_history }) => {
+            try {
+                const params = new URLSearchParams();
+                if (keep_history !== undefined)
+                    params.append("keep_history", String(keep_history));
+
+                const qs = params.toString();
+                const response = await api.delete(
+                    `/crypto/manual/${crypto_id}${qs ? `?${qs}` : ""}`,
+                );
+
+                if (response.status === 204) {
+                    return successResponse("Manual crypto balance deleted.");
+                }
+
+                if (!response.ok) {
+                    return handleApiError(
+                        response,
+                        "Failed to delete manual crypto balance",
                     );
                 }
 
                 return dataResponse(await response.json());
             } catch (error) {
-                return catchError(error, "Failed to update crypto asset");
+                return catchError(
+                    error,
+                    "Failed to delete manual crypto balance",
+                );
+            }
+        },
+    );
+
+    server.registerTool(
+        "get_all_synced_crypto",
+        {
+            description:
+                "Get all synced crypto accounts (Coinbase, Kraken, Ethereum wallets) and their nested per-symbol balances. Synced accounts are connected in the Lunch Money web app and cannot be created or edited through the API.",
+            annotations: {
+                readOnlyHint: true,
+            },
+        },
+        async () => {
+            try {
+                const response = await api.get("/crypto/synced");
+
+                if (!response.ok) {
+                    return handleApiError(
+                        response,
+                        "Failed to get synced crypto accounts",
+                    );
+                }
+
+                const data: { crypto_synced: SyncedCryptoAccount[] } =
+                    await response.json();
+                return dataResponse(data);
+            } catch (error) {
+                return catchError(
+                    error,
+                    "Failed to get synced crypto accounts",
+                );
+            }
+        },
+    );
+
+    server.registerTool(
+        "get_single_synced_crypto",
+        {
+            description:
+                "Get a single synced crypto account and all its nested balances by ID.",
+            inputSchema: {
+                crypto_id: z.coerce
+                    .number()
+                    .int()
+                    .describe("Id of the synced crypto account to retrieve."),
+            },
+            annotations: {
+                readOnlyHint: true,
+            },
+        },
+        async ({ crypto_id }) => {
+            try {
+                const response = await api.get(`/crypto/synced/${crypto_id}`);
+
+                if (!response.ok) {
+                    return handleApiError(
+                        response,
+                        "Failed to get synced crypto account",
+                    );
+                }
+
+                const data: SyncedCryptoAccount = await response.json();
+                return dataResponse(data);
+            } catch (error) {
+                return catchError(error, "Failed to get synced crypto account");
+            }
+        },
+    );
+
+    server.registerTool(
+        "get_synced_crypto_balance",
+        {
+            description:
+                "Get a single balance held inside a synced crypto account, looked up by its cryptocurrency symbol.",
+            inputSchema: {
+                crypto_id: z.coerce
+                    .number()
+                    .int()
+                    .describe("Id of the synced crypto account."),
+                symbol: z
+                    .string()
+                    .min(1)
+                    .max(25)
+                    .describe(
+                        "Cryptocurrency symbol held within the synced account, e.g. 'eth'.",
+                    ),
+            },
+            annotations: {
+                readOnlyHint: true,
+            },
+        },
+        async ({ crypto_id, symbol }) => {
+            try {
+                const response = await api.get(
+                    `/crypto/synced/${crypto_id}/${encodeURIComponent(symbol)}`,
+                );
+
+                if (!response.ok) {
+                    return handleApiError(
+                        response,
+                        "Failed to get synced crypto balance",
+                    );
+                }
+
+                const data: SyncedCryptoBalance = await response.json();
+                return dataResponse(data);
+            } catch (error) {
+                return catchError(error, "Failed to get synced crypto balance");
+            }
+        },
+    );
+
+    server.registerTool(
+        "refresh_synced_crypto",
+        {
+            description:
+                "Trigger a balance refresh for a synced crypto account and return the refreshed account. Reaches out to the external crypto provider.",
+            inputSchema: {
+                crypto_id: z.coerce
+                    .number()
+                    .int()
+                    .describe("Id of the synced crypto account to refresh."),
+            },
+            annotations: {
+                openWorldHint: true,
+            },
+        },
+        async ({ crypto_id }) => {
+            try {
+                const response = await api.post(
+                    `/crypto/synced/${crypto_id}/refresh`,
+                );
+
+                if (!response.ok) {
+                    return handleApiError(
+                        response,
+                        "Failed to refresh synced crypto account",
+                    );
+                }
+
+                const data: SyncedCryptoAccount = await response.json();
+                return dataResponse(data);
+            } catch (error) {
+                return catchError(
+                    error,
+                    "Failed to refresh synced crypto account",
+                );
             }
         },
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,19 +132,51 @@ export interface PlaidAccount {
     plaid_last_successful_update: string | null;
 }
 
-export interface CryptoAsset {
-    id?: number | null;
-    zabo_account_id?: number | null;
-    source: "manual" | "synced";
+export interface Cryptocurrency {
+    id: number;
+    coingecko_id: string;
+    symbol: string;
+    full_name: string;
+}
+
+export interface ManualCrypto {
+    id: number;
+    name: string;
+    display_name: string | null;
+    institution_name: string | null;
+    balance: string;
+    symbol: string;
+    coingecko_id: string | null;
+    to_base: number | null;
+    balance_as_of: string | null;
+    exchange_rate_as_of: string | null;
+    created_by_name: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface SyncedCryptoBalance {
     name: string;
     display_name: string | null;
     balance: string;
-    balance_as_of?: string;
-    currency: string;
-    status: string;
-    institution_name: string | null;
+    symbol: string;
+    coingecko_id: string | null;
+    to_base: number | null;
+    balance_as_of: string | null;
+    exchange_rate_as_of: string | null;
+    updated_at: string;
+}
+
+export interface SyncedCryptoAccount {
+    id: number;
+    provider: "kraken" | "coinbase" | "ethereum";
+    status: "active" | "unsupported" | "relink" | "initializing";
+    created_by_name: string | null;
     created_at: string;
-    to_base?: number | null;
+    updated_at: string;
+    last_import?: string | null;
+    display_name: string | null;
+    balances: SyncedCryptoBalance[];
 }
 
 export type BalanceHistoryAccountType =


### PR DESCRIPTION
Crypto was the last domain still calling `dev.lunchmoney.app/v1`. This moves it to v2's [crypto-manual](https://lunchmoney.dev/v2/docs#tag/crypto-manual) and [crypto-synced](https://lunchmoney.dev/v2/docs#tag/crypto-synced) endpoints, so the server no longer talks to v1 at all. Tool count grows from 50 to 59.

Everything outside the crypto domain is untouched.

## Breaking

- **`get_all_crypto` is removed.** v2 splits crypto into separate manual and synced resources with different shapes and offers no equivalent of v1's combined `GET /crypto`. Use `get_all_manual_crypto` + `get_all_synced_crypto` — together they return everything it did, with more detail.
- **`update_manual_crypto` drops its `currency` parameter.** A manual balance's symbol is fixed at creation and v2 ignores attempts to change it. All writable fields are now optional, but at least one must be supplied.

## Tools

| Tool | Endpoint |
|---|---|
| `get_supported_cryptocurrencies` / `add_supported_cryptocurrency` | `GET`/`POST /cryptocurrencies` |
| `get_all_manual_crypto` / `create_manual_crypto` | `GET`/`POST /crypto/manual` |
| `get_single_manual_crypto` / `update_manual_crypto` / `delete_manual_crypto` | `GET`/`PUT`/`DELETE /crypto/manual/{id}` |
| `get_all_synced_crypto` / `get_single_synced_crypto` | `GET /crypto/synced[/{id}]` |
| `get_synced_crypto_balance` | `GET /crypto/synced/{id}/{symbol}` |
| `refresh_synced_crypto` | `POST /crypto/synced/{id}/refresh` |

The docs page linked above is a client-rendered SPA; the underlying spec is at `https://lunchmoney.dev/v2/openapi`, which is what these were built against.

## Beyond the mechanical port

- **Precision bug fixed (pre-existing).** The v1 code did `z.coerce.number()` then `.toString()`. v2 carries balances to 18 decimals — more than a double holds — so `0.852341920145782301` was silently rounding on write. Balances are now forwarded exactly as supplied. Numbers are passed through unconverted rather than stringified, because `String(1e-8)` is `"1e-8"` — exponential notation that the decimal format rejects, which would have made one satoshi unrepresentable.
- **`DELETE /crypto/manual/{id}` returns 422 demanding an explicit `keep_history`** when the asset has balance history. Its context fields (`crypto_manual_id`, `has_balance_history`, `required_parameter`, …) are added to `V2_ERROR_HINT_FIELDS` so the model can retry without a round-trip, matching how `src/errors.ts` already handles other recoverable errors.
- Removed `apiV1` and the `baseUrlOverride` param it relied on — crypto was the only consumer.
- `CryptoAsset` replaced by `Cryptocurrency`, `ManualCrypto`, `SyncedCryptoBalance`, `SyncedCryptoAccount`, and the handlers now annotate their parses with them.

## Why 3.0.0

Removing a publicly callable tool is a backward-incompatible change under semver, and this repo's own precedent agrees: all 8 tool removals in its history happened in the single major bump (2.0.0), and no minor or patch has ever removed one. `get_all_crypto` has shipped in every release since 1.0.0.

Notably, when 2.0.0 hit this same wall — v2 had no crypto endpoints — it kept the tool names and reimplemented them over `/manual_accounts` rather than remove them. I considered a similar shim here, but v1 returned `source`/`currency`/`status` fields v2 doesn't have, so it would return a differently-shaped payload under an unchanged name. That wrapper approach was already tried and walked back in 2.0.1.

## Testing

`npm test` passes (78/78) and the build is clean, but note the suite only covers `src/attachments.ts` — it typechecks this work without exercising it. The endpoints were verified against the published OpenAPI spec and confirmed live, but the request/response round-trip still needs `npm run dev` against a real account, particularly `create_manual_crypto` and the `delete_manual_crypto` 422 path.

## Before merging

`.github/workflows/publish-mcp.yml` runs on push to `main` and publishes when `package.json` carries an unpublished version. **Merging this releases 3.0.0 to npm and the MCP Registry.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)